### PR TITLE
feat(deps): added devforge installation to dependency scripts

### DIFF
--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -228,6 +228,18 @@ install_claude_cli() {
     npm install -g @anthropic-ai/claude-code
 }
 
+# https://github.com/rios0rios0/devforge
+install_devforge() {
+    binPath="$HOME/.local/bin"
+    devBin="$binPath/dev"
+
+    if [ ! -f "$devBin" ]; then
+        curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh | bash
+    else
+        echo "Devforge is already installed."
+    fi
+}
+
 # https://1password.com/downloads/command-line/
 install_1password_cli() {
     binPath="$HOME/.local/bin"
@@ -344,6 +356,7 @@ install_sdkman
 install_nvm
 install_gemini_cli
 install_claude_cli
+install_devforge
 
 # TODO: same of the line 261
 install_pyenv

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -234,7 +234,17 @@ install_devforge() {
     devBin="$binPath/dev"
 
     if [ ! -f "$devBin" ]; then
-        curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh | bash
+        local installer
+        installer="$(mktemp)"
+        if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh -o "$installer"; then
+            echo "[devforge] ERROR: failed to download installer" >&2
+            rm -f "$installer"
+            return 1
+        fi
+        bash "$installer"
+        local status=$?
+        rm -f "$installer"
+        if [ "$status" -ne 0 ]; then return "$status"; fi
     else
         echo "Devforge is already installed."
     fi

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -183,6 +183,11 @@ install_gemini_cli() {
     npm install -g @google/gemini-cli
 }
 
+# https://github.com/rios0rios0/devforge
+install_devforge() {
+    curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh | bash
+}
+
 # https://cli.github.com/manual/installation
 install_github_cli() {
     sudo mkdir -p -m 755 /etc/apt/keyrings
@@ -227,6 +232,7 @@ install_pyenv
 install_cursor_cli
 install_claude_cli
 install_gemini_cli
+install_devforge
 
 install_github_cli
 install_azure_cli

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -185,7 +185,21 @@ install_gemini_cli() {
 
 # https://github.com/rios0rios0/devforge
 install_devforge() {
-    curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh | bash
+    local installer
+    local status
+
+    installer="$(mktemp)"
+    if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh -o "$installer"; then
+        echo "[devforge] ERROR: failed to download installer" >&2
+        rm -f "$installer"
+        return 1
+    fi
+
+    bash "$installer"
+    status=$?
+    rm -f "$installer"
+
+    return "$status"
 }
 
 # https://cli.github.com/manual/installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added [devforge](https://github.com/rios0rios0/devforge) (`dev` CLI) installation to Linux/WSL and Android dependency scripts
+
 ## [0.5.0] - 2026-04-01
 
 ### Added


### PR DESCRIPTION
## Summary

- Added `install_devforge` function to both Linux/WSL and Android dependency scripts using the official [install.sh](https://github.com/rios0rios0/devforge) from the devforge repository
- The `dev` binary was already referenced in `.zshrc` (`dev project use .`) but never installed by chezmoi
- Android script includes idempotency check (`[ ! -f "$devBin" ]`), consistent with other tools in that script

## Test plan

- [ ] Run `chezmoi apply --dry-run --verbose` on Linux/WSL to verify no errors
- [ ] Run `chezmoi apply --dry-run --verbose` on Android/Termux to verify no errors
- [ ] Verify `dev --version` works after a fresh apply on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)