### PR TITLE
feat(android): added rclone to Termux dependencies

### DIFF
--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -56,6 +56,7 @@ utilities=(
     "openssh"           # used to clone Git repositories and also authentication
     "parallel"          # it runs many threads of a command at the same time
     "rsync"             # provides file sync function
+    "rclone"            # it's for syncing files with cloud storage (OneDrive, Google Drive, S3, etc.)
     "dnsutils"          # provides "nslookup" function
     "tmux"              # terminal multiplexer for managing multiple sessions under one process tree
 )

--- a/.docs/rclone-onedrive-setup.md
+++ b/.docs/rclone-onedrive-setup.md
@@ -1,0 +1,122 @@
+# rclone OneDrive Setup Guide
+
+A guide for configuring rclone with Microsoft OneDrive on Termux (Android).
+
+## Why rclone?
+
+On Termux, rclone is the best option for cloud storage sync:
+
+- Available via `apt install rclone` (no manual builds)
+- Native OneDrive support with OAuth authentication
+- Supports copy, sync, move, and ls operations
+- Scriptable for automated backups
+
+Alternatives like the dedicated `onedrive` CLI (D-lang) are impractical to build on Termux, and `termux-share` only handles one file at a time.
+
+## Initial Setup
+
+### 1. Start the configuration wizard
+
+```bash
+rclone config
+```
+
+### 2. Walk through the prompts
+
+| Prompt | Answer |
+|--------|--------|
+| `e/n/d/r/c/s/q>` | `n` (new remote) |
+| `name>` | `onedrive` |
+| `Storage>` | `onedrive` (or type the number next to "Microsoft OneDrive") |
+| `client_id>` | Press Enter (leave blank) |
+| `client_secret>` | Press Enter (leave blank) |
+| `region>` | `1` (Microsoft Cloud Global) |
+| `Edit advanced config?` | `n` |
+| `Use web browser to automatically authenticate?` | `n` (Termux has no browser) |
+
+### 3. Authenticate via browser
+
+rclone prints a URL like:
+
+```
+If your browser doesn't open automatically go to the following link: https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...
+```
+
+**Important:** Open this URL in an **incognito/private browser tab** on your phone. This prevents the login page from auto-selecting a cached work/school account when you want to use a personal Microsoft account.
+
+1. Sign in with your Microsoft account
+2. Grant the requested permissions
+3. The browser redirects to `localhost` with a token -- copy the **entire URL** from the address bar
+4. Paste it back into the Termux prompt
+
+### 4. Choose drive type
+
+| Prompt | Answer |
+|--------|--------|
+| `config_type>` | `1` (OneDrive Personal or Business) |
+| `config_driveid>` | Press Enter (accepts the detected drive) |
+| `Is this okay?` | `y` |
+| `e/n/d/r/c/s/q>` | `q` (quit config) |
+
+### 5. Verify
+
+```bash
+rclone lsd onedrive:      # list top-level folders
+rclone about onedrive:    # show storage usage
+```
+
+## Common Commands
+
+### List files and directories
+
+```bash
+rclone lsd onedrive:              # list top-level directories
+rclone ls onedrive:Documents/     # list all files in Documents recursively
+rclone lsl onedrive:Documents/    # list with sizes and timestamps
+```
+
+### Upload files
+
+```bash
+# copy a single file
+rclone copy ~/file.pdf onedrive:Documents/
+
+# copy an entire directory (creates it if it doesn't exist)
+rclone copy ~/Pictures onedrive:Pictures/
+
+# copy with progress bar
+rclone copy ~/backup onedrive:Backups/ --progress
+```
+
+### Sync a directory
+
+```bash
+# make remote match local (deletes remote files not present locally)
+rclone sync ~/Documents onedrive:Documents/ --progress
+
+# dry run first to see what would change
+rclone sync ~/Documents onedrive:Documents/ --dry-run
+```
+
+### Download files
+
+```bash
+rclone copy onedrive:Documents/report.pdf ~/Downloads/
+```
+
+### Other operations
+
+```bash
+rclone mkdir onedrive:NewFolder           # create a directory
+rclone delete onedrive:OldFolder/         # delete files (not directories)
+rclone purge onedrive:OldFolder/          # delete directory and all contents
+rclone move ~/file.txt onedrive:Documents/ # move (deletes local after upload)
+```
+
+## Tips
+
+- **Bandwidth limit:** use `--bwlimit 1M` to cap upload speed (useful on mobile data)
+- **Exclude patterns:** use `--exclude "*.tmp"` to skip files
+- **Config location:** rclone stores its config at `~/.config/rclone/rclone.conf`
+- **Token refresh:** rclone automatically refreshes the OAuth token; re-auth is only needed if the token is revoked or expires after prolonged inactivity
+- **Multiple remotes:** run `rclone config` again to add Google Drive, S3, or other providers alongside OneDrive

--- a/.docs/rclone-onedrive-setup.md
+++ b/.docs/rclone-onedrive-setup.md
@@ -32,7 +32,7 @@ rclone config
 | `client_secret>` | Press Enter (leave blank) |
 | `region>` | `1` (Microsoft Cloud Global) |
 | `Edit advanced config?` | `n` |
-| `Use web browser to automatically authenticate?` | `n` (Termux has no browser) |
+| `Use web browser to automatically authenticate?` | `n` (Termux cannot auto-launch a browser; copy the URL and open it manually or use `termux-open-url <url>`) |
 
 ### 3. Authenticate via browser
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,16 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `rclone` to Android/Termux dependencies for cloud storage sync (OneDrive, Google Drive, S3)
+- added rclone OneDrive setup guide (`.docs/rclone-onedrive-setup.md`)
+
 ## [0.6.0] - 2026-04-03
 
 ### Added
 
 - added [devforge](https://github.com/rios0rios0/devforge) (`dev` CLI) installation to Linux/WSL and Android dependency scripts
-- added `rclone` to Android/Termux dependencies for cloud storage sync (OneDrive, Google Drive, S3)
-- added rclone OneDrive setup guide (`.docs/rclone-onedrive-setup.md`)
 
 ## [0.5.0] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added [devforge](https://github.com/rios0rios0/devforge) (`dev` CLI) installation to Linux/WSL and Android dependency scripts
+- added `rclone` to Android/Termux dependencies for cloud storage sync (OneDrive, Google Drive, S3)
+- added rclone OneDrive setup guide (`.docs/rclone-onedrive-setup.md`)
 
 ## [0.5.0] - 2026-04-01
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/), [1Passw
 
 ### Utilities
 
-- eza (ls replacement), bat (syntax highlighting), ripgrep, jq/yq, ffmpeg, ImageMagick, pdftk, asciinema, Speedtest CLI, CycloneDX (SBOM)
+- eza (ls replacement), bat (syntax highlighting), ripgrep, jq/yq, ffmpeg, ImageMagick, pdftk, asciinema, Speedtest CLI, CycloneDX (SBOM), rclone (see the [OneDrive setup guide](.docs/rclone-onedrive-setup.md))
 
 ## Platform Matrix
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/), [1Passw
 
 ### Utilities
 
-- eza (ls replacement), bat (syntax highlighting), ripgrep, jq/yq, ffmpeg, ImageMagick, pdftk, asciinema, Speedtest CLI, CycloneDX (SBOM), rclone (see the [OneDrive setup guide](.docs/rclone-onedrive-setup.md))
+- eza (ls replacement), bat (syntax highlighting), ripgrep, jq/yq, ffmpeg, ImageMagick, pdftk, asciinema, Speedtest CLI, CycloneDX (SBOM), rclone (Android/Termux only; see the [OneDrive setup guide](.docs/rclone-onedrive-setup.md))
 
 ## Platform Matrix
 


### PR DESCRIPTION
## Summary

- Added `rclone` to the Android/Termux install script utilities array for cloud storage sync (OneDrive, Google Drive, S3, etc.)
- Created `.docs/rclone-onedrive-setup.md` with step-by-step OneDrive configuration, authentication walkthrough, and common commands
- Referenced the setup guide in `README.md` under Utilities

## Test plan

- [ ] Run `chezmoi diff` to confirm only the install script is affected in managed files
- [ ] Verify `.docs/` is not in `chezmoi status` output (already ignored via `.chezmoiignore`)
- [ ] Confirm `rclone` installs via `apt install rclone` on a fresh Termux setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)