### PR TITLE
fix(docker): added ACR identity token support to docker config template

### DIFF
--- a/dot_docker/config.json.tmpl
+++ b/dot_docker/config.json.tmpl
@@ -23,23 +23,33 @@
     {{-         end }}
     {{-       end }}
     {{-       $registryUsername := "" }}
-    {{-       if hasKey $f "username" }}{{ $registryUsername = index $f "username" }}{{ end }}
+    {{-       if hasKey $f "username" }}{{ $registryUsername = trim (index $f "username") }}{{ end }}
     {{-       $registryCredential := "" }}
     {{-       if hasKey $f "credential" }}{{ $registryCredential = trim (index $f "credential") }}{{ end }}
     {{-       $registryName := index $f "registry name" }}
     {{-       $identityToken := "" }}
     {{-       if hasKey $f "identitytoken" }}
-    {{-         $identityToken = index $f "identitytoken" }}
+    {{-         $identityToken = trim (index $f "identitytoken") }}
     {{-       end }}
-    {{-       warnf "[docker-config] configuring registry \"%s\"" $registryName }}
+    {{-       $hasAuth := and (ne $registryUsername "") (ne $registryCredential "") }}
+    {{-       $hasIdentityToken := ne $identityToken "" }}
+    {{-       if or $hasAuth $hasIdentityToken }}
+    {{-         warnf "[docker-config] configuring registry \"%s\"" $registryName }}
     {{- if not $first }},{{ end }}
     "{{ $registryName }}": {
+    {{- if $hasAuth }}
       "auth": "{{ b64enc (list $registryUsername ":" $registryCredential | join "") }}"
-    {{- if ne $identityToken "" }},
+    {{- if $hasIdentityToken }},
+      "identitytoken": "{{ $identityToken }}"
+    {{- end }}
+    {{- else }}
       "identitytoken": "{{ $identityToken }}"
     {{- end }}
     }
-    {{-       $first = false }}
+    {{-         $first = false }}
+    {{-       else }}
+    {{-         warnf "[docker-config] WARN: skipping registry \"%s\" because neither valid auth nor identitytoken is available" $registryName }}
+    {{-       end }}
     {{-     end }}
     {{-   end }}
     {{- end }}

--- a/dot_docker/config.json.tmpl
+++ b/dot_docker/config.json.tmpl
@@ -22,13 +22,22 @@
     {{-           $_ := set $f .label .value }}
     {{-         end }}
     {{-       end }}
-    {{-       $registryUsername := index $f "username" }}
-    {{-       $registryCredential := index $f "credential" }}
+    {{-       $registryUsername := "" }}
+    {{-       if hasKey $f "username" }}{{ $registryUsername = index $f "username" }}{{ end }}
+    {{-       $registryCredential := "" }}
+    {{-       if hasKey $f "credential" }}{{ $registryCredential = trim (index $f "credential") }}{{ end }}
     {{-       $registryName := index $f "registry name" }}
+    {{-       $identityToken := "" }}
+    {{-       if hasKey $f "identitytoken" }}
+    {{-         $identityToken = index $f "identitytoken" }}
+    {{-       end }}
     {{-       warnf "[docker-config] configuring registry \"%s\"" $registryName }}
     {{- if not $first }},{{ end }}
     "{{ $registryName }}": {
       "auth": "{{ b64enc (list $registryUsername ":" $registryCredential | join "") }}"
+    {{- if ne $identityToken "" }},
+      "identitytoken": "{{ $identityToken }}"
+    {{- end }}
     }
     {{-       $first = false }}
     {{-     end }}


### PR DESCRIPTION
## Summary
- Added `identitytoken` field support to the docker config template for Azure Container Registry OAuth2/refresh token authentication
- Guarded `username` and `credential` field lookups with `hasKey` to prevent template failures when fields are missing
- Updated 1Password items (Azure Container Registry dev/prod) with identity token credentials and fixed device note references on `alien-a51` and `mxhero-z790` to point to both `(dev)` and `(prod)` items

## Test plan
- [ ] Run `chezmoi apply` and verify `~/.docker/config.json` contains both `auth` and `identitytoken` for ACR registries
- [ ] Verify non-ACR registries (GitHub, Docker Hub) still generate correctly with `auth` only
- [ ] Verify `docker pull devsharedeastus.azurecr.io/<image>` works with the generated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)