### PR TITLE
feat(ggshield): add global pre-commit hook via chezmoi

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -33,6 +33,7 @@ AppData
 {{- /* Linux‑exclusive files – only for Linux. When not running Linux, ignore them. */ -}}
 {{- if ne .chezmoi.os "linux" }}
 .chezmoiscripts/linux-*.sh
+.config/ggshield
 .docker
 .histdb
 .john

--- a/.chezmoiscripts/run_after_linux-004-install-ggshield-hook.sh
+++ b/.chezmoiscripts/run_after_linux-004-install-ggshield-hook.sh
@@ -8,15 +8,23 @@ set -euo pipefail
 
 prefix="ggshield-hook"
 
-if ! command -v ggshield &>/dev/null; then
-    echo "[$prefix] WARN: ggshield not found on PATH, skipping" >&2
+ggshield_bin=""
+
+# Non-interactive chezmoi runs may not have ~/.local/bin on PATH (pipx's default
+# bin dir), so fall back to a direct file check before giving up.
+if command -v ggshield &>/dev/null; then
+    ggshield_bin="$(command -v ggshield)"
+elif [[ -x "$HOME/.local/bin/ggshield" ]]; then
+    ggshield_bin="$HOME/.local/bin/ggshield"
+else
+    echo "[$prefix] WARN: ggshield not found on PATH or at ~/.local/bin/ggshield, skipping" >&2
     exit 0
 fi
 
 # --mode global writes the hook script into the shared git-hooks dir.
 # It also *attempts* to set core.hooksPath globally, but since we already
 # own that setting via dot_gitconfig.tmpl the net result is unchanged.
-ggshield install --mode global --force >&2 || {
+"$ggshield_bin" install --mode global --force >&2 || {
     echo "[$prefix] ERROR: failed to install ggshield global hook" >&2
     exit 1
 }

--- a/.chezmoiscripts/run_after_linux-004-install-ggshield-hook.sh
+++ b/.chezmoiscripts/run_after_linux-004-install-ggshield-hook.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Idempotent: (re)generates the ggshield global pre-commit hook script at
+# ~/.local/share/ggshield/git-hooks/pre-commit. The matching core.hooksPath
+# in ~/.gitconfig is set by dot_gitconfig.tmpl — no git config mutation here.
+
+set -euo pipefail
+
+prefix="ggshield-hook"
+
+if ! command -v ggshield &>/dev/null; then
+    echo "[$prefix] WARN: ggshield not found on PATH, skipping" >&2
+    exit 0
+fi
+
+# --mode global writes the hook script into the shared git-hooks dir.
+# It also *attempts* to set core.hooksPath globally, but since we already
+# own that setting via dot_gitconfig.tmpl the net result is unchanged.
+ggshield install --mode global --force >&2 || {
+    echo "[$prefix] ERROR: failed to install ggshield global hook" >&2
+    exit 1
+}
+
+echo "[$prefix] global pre-commit hook ready" >&2

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -316,6 +316,27 @@ install_azure_cli() {
     pip install azure-cli
 }
 
+# https://docs.gitguardian.com/ggshield-docs/getting-started
+install_ggshield() {
+    # Ensure pip is available from pyenv's Python (so pipx lives in the managed Python)
+    export PYENV_ROOT="$HOME/.pyenv"
+    export PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+
+    if ! command -v pipx &>/dev/null; then
+        pip install --upgrade pipx
+        pipx ensurepath
+    else
+        echo "[configure-deps] pipx is already installed, skipping" >&2
+    fi
+
+    if pipx list --short 2>/dev/null | grep -q '^ggshield '; then
+        echo "[configure-deps] ggshield is already installed, skipping" >&2
+    else
+        pipx install ggshield
+    fi
+}
+
 # https://www.speedtest.net/apps/cli
 install_speedtest_cli() {
     if command -v speedtest &>/dev/null; then
@@ -347,6 +368,8 @@ install_devforge
 
 install_github_cli
 install_azure_cli
+
+install_ggshield
 
 install_speedtest_cli
 # =========================================================================================================

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -323,17 +323,25 @@ install_ggshield() {
     export PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
 
-    if ! command -v pipx &>/dev/null; then
-        pip install --upgrade pipx
-        pipx ensurepath
+    # Use `python -m pipx` throughout to avoid pyenv shim timing issues:
+    # `pip install pipx` places the shim, but it only becomes callable after
+    # `pyenv rehash`, which isn't guaranteed in a non-interactive script context.
+    if ! python -m pip show pipx &>/dev/null; then
+        python -m pip install --upgrade pipx
+        python -m pipx ensurepath
     else
         echo "[configure-deps] pipx is already installed, skipping" >&2
     fi
 
-    if pipx list --short 2>/dev/null | grep -q '^ggshield '; then
+    if python -m pipx list --short 2>/dev/null | grep -q '^ggshield '; then
         echo "[configure-deps] ggshield is already installed, skipping" >&2
     else
-        pipx install ggshield
+        python -m pipx install ggshield
+    fi
+
+    if ! python -m pipx list --short 2>/dev/null | grep -q '^ggshield '; then
+        echo "[configure-deps] ERROR: ggshield installation failed" >&2
+        exit 1
     fi
 }
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,6 +78,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
   - **Gemini CLI** (`@google/gemini-cli` npm package)
   - **GitHub CLI** (gh, via apt repository)
   - **Azure CLI** (via pip, installed into pyenv Python)
+  - **ggshield** (GitGuardian CLI, via pipx) — installs a global pre-commit hook script at `~/.local/share/ggshield/git-hooks/pre-commit`; `core.hooksPath` in `~/.gitconfig` points all repos there
   - **Speedtest CLI** (Ookla, via packagecloud)
 - Each tool installation can take 5-15 minutes individually
 - **Critical**: Script requires internet access for downloading tools
@@ -130,6 +131,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - `run_once_after_windows-001-create-ssh-known-hosts.ps1` — pre-populates `~/.ssh/known_hosts` for GitHub, GitLab, Azure DevOps, Bitbucket (avoids SSH freeze in WSL)
 - `run_after_linux-001-execute-chezmoi-templates.sh` — re-processes `~/.scripts/*-template.sh` files through `chezmoi execute-template`
 - `run_after_linux-002-import-gpg-keys.sh.tmpl` — imports GPG keys from 1Password (device note, `gpg:` entries)
+- `run_after_linux-004-install-ggshield-hook.sh` — (re)generates the ggshield global pre-commit hook script; idempotent
 - `run_after_windows-001-create-ssh-public-keys.ps1.tmpl` — creates SSH public key files from 1Password (device note, `ssh:` entries)
 - `run_after_windows-002-create-ssh-pems.ps1.tmpl` — creates SSH PEM files on Windows (device note, `pem:` entries)
 - `run_after_windows-003-copy-app-data-files.ps1.tmpl` — copies files from `AppData/` in the repo to `~\AppData\` on Windows (directory names use `+` as wildcard for version-specific paths)
@@ -402,7 +404,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `op-wrapper`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `op-wrapper`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`, `ggshield-auth`, `ggshield-hook`
 
 ## Security and Encryption
 - Private key location: `~/.ssh/chezmoi` (Linux/Windows) or via `op` wrapper (Android)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `ggshield` (GitGuardian CLI) installation to Linux dependencies via pipx
+- added global ggshield pre-commit hook on Linux via `core.hooksPath` in `dot_gitconfig.tmpl`, covering all existing and future repositories without per-repo setup
+- added `run_after_linux-004-install-ggshield-hook.sh` to (re)generate the shared ggshield hook script on every apply
+- added `dot_config/ggshield/auth_config.yaml.tmpl` rendering the ggshield auth config from 1Password item `Token: ggshield` (fields: `token`, `token name`, `workspace id`)
+
 ### Changed
 
 - changed 1Password organization from type-centric "Active *" notes to device-centric "Device: \<name\>" notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`, `git-clone`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`, `git-clone`, `ggshield-auth`, `ggshield-hook`
 
 ## Important Timing Constraints
 

--- a/dot_config/ggshield/auth_config.yaml.tmpl
+++ b/dot_config/ggshield/auth_config.yaml.tmpl
@@ -1,0 +1,38 @@
+{{- /*
+  Renders ~/.config/ggshield/auth_config.yaml from a 1Password item so
+  ggshield works out of the box after `chezmoi apply` — no `ggshield auth
+  login` needed.
+
+  Required 1Password setup (once, per user — not per device):
+    Vault:  Private
+    Item:   "Token: ggshield"
+    Fields:
+      - token        (concealed) — the gg_pat_* personal access token
+      - token name   (text)      — display name shown by `ggshield auth list`
+      - workspace id (text)      — GitGuardian workspace id (e.g. 371781)
+
+  Rotate the token from https://dashboard.gitguardian.com/api/personal-access-tokens
+  and update the 1Password fields — the next `chezmoi apply` propagates it.
+*/ -}}
+{{- warnf "[ggshield-auth] fetching 1Password item Token: ggshield..." -}}
+{{- $item := onepassword "Token: ggshield" "Private" "my" -}}
+{{- $f := dict -}}
+{{- range $item.fields -}}
+  {{- if hasKey . "value" -}}
+    {{- $_ := set $f .label .value -}}
+  {{- end -}}
+{{- end -}}
+{{- $token := index $f "token" -}}
+{{- $tokenName := index $f "token name" -}}
+{{- $workspaceId := index $f "workspace id" -}}
+default_token_lifetime: null
+instances:
+- accounts:
+  - expire_at: null
+    token: {{ $token }}
+    token_name: {{ $tokenName }}
+    type: personal_access_token
+    workspace_id: {{ $workspaceId }}
+  default_token_lifetime: null
+  name: null
+  url: https://dashboard.gitguardian.com

--- a/dot_config/ggshield/private_auth_config.yaml.tmpl
+++ b/dot_config/ggshield/private_auth_config.yaml.tmpl
@@ -29,10 +29,10 @@ default_token_lifetime: null
 instances:
 - accounts:
   - expire_at: null
-    token: {{ $token }}
-    token_name: {{ $tokenName }}
+    token: "{{ $token }}"
+    token_name: "{{ $tokenName }}"
     type: personal_access_token
-    workspace_id: {{ $workspaceId }}
+    workspace_id: "{{ $workspaceId }}"
   default_token_lifetime: null
   name: null
   url: https://dashboard.gitguardian.com

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -141,6 +141,9 @@
     editor = vim
     excludesfile = "{{ $excludesFile }}"
     sshCommand = "{{ $sshCommand }}"
+{{- if eq .chezmoi.os "linux" }}
+    hooksPath = "{{ .chezmoi.homeDir }}/.local/share/ggshield/git-hooks"
+{{- end }}
 [merge]
     commit = yes
     ff = yes


### PR DESCRIPTION
## Summary

Makes ggshield secret-scanning portable across every machine managed by chezmoi. After `chezmoi apply`, every existing and future repo gets secret scanning on `git commit` with no per-repo configuration.

- **Install** — `install_ggshield()` added to the Linux deps script; installs pipx (if missing) and then `pipx install ggshield`.
- **Wire** — `dot_gitconfig.tmpl` sets `core.hooksPath = ~/.local/share/ggshield/git-hooks` on Linux, routing every repo's hooks to the shared script.
- **Generate hook** — `run_after_linux-004-install-ggshield-hook.sh` runs `ggshield install --mode global --force` on every apply so the hook script is always current.
- **Auth** — `dot_config/ggshield/auth_config.yaml.tmpl` renders the auth config from a 1Password item, so a new machine authenticates without running `ggshield auth login`.

## Required one-time 1Password setup

Create this item so the auth template resolves:

- **Vault**: `Private`
- **Item name**: `Token: ggshield`
- **Fields**:
  - `token` (concealed) — the `gg_pat_*` personal access token from https://dashboard.gitguardian.com/api/personal-access-tokens
  - `token name` (text) — display name shown by `ggshield auth list`
  - `workspace id` (text) — GitGuardian workspace id (e.g. `371781`)

To rotate the token, update these fields in 1Password and re-run `chezmoi apply`.

## Scope

Linux/WSL only. `.chezmoiignore` already excludes `.config/ggshield` on non-Linux; `hooksPath` is gated on `.chezmoi.os == "linux"`. Windows/Android coverage can be added later if needed.

## Test plan

- [ ] Create the 1Password item above
- [ ] Run `chezmoi diff` — confirm gitconfig gets `hooksPath` and the new `~/.config/ggshield/auth_config.yaml` renders
- [ ] Run `chezmoi apply` — confirm `ggshield --version` works and `~/.local/share/ggshield/git-hooks/pre-commit` exists
- [ ] Confirm `git config --global core.hooksPath` equals the ggshield path
- [ ] Make a throwaway commit with a fake AWS key (`AKIAIOSFODNN7EXAMPLE`) in any repo and confirm the hook rejects it
- [ ] Verify `ggshield auth list` shows the account without running `ggshield auth login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)