### PR TITLE
feat(termux): add send() zsh function to upload files to OneDrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added staged JetBrains theme assets under `dot_local/share/jetbrains-themes/` (`Darcula Coder.icls`, `Dark Coder.icls`, `Coder.xml` code style, `Dark Coder.xml` Material Theme UI variant) migrated from the legacy `WKSetup` repo
 - added `run_after_linux-005-install-jetbrains-themes.sh` and `run_after_windows-004-install-jetbrains-themes.ps1` to fan the staged themes out into every detected JetBrains IDE config directory (`~/.config/JetBrains/*/` on Linux, `%APPDATA%\JetBrains\*\` on Windows) into `colors/`, `codestyles/`, and `materialCustomThemes/`
 - added `rec` alias for `asciinema rec` in `dot_zshrc.tmpl` (matches the shorthand from the legacy `WKSetup` repo)
+- added `send` zsh function in `dot_zshrc.tmpl` (Android/Termux-only) that uploads files and directories to the OneDrive `Downloads/` folder via rclone; directories preserve their basename in the destination, and the function guards against missing rclone or an unconfigured `onedrive:` remote
 - set `AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO=1 PIP_NO_BINARY=awscrt` on the Android/Termux AWS CLI v2 build so `awscrt` links against Termux's OpenSSL 3.x instead of its bundled libcrypto that still references the removed `FIPS_mode` symbol (fixes `ImportError: cannot locate symbol "FIPS_mode"` when loading `_awscrt.abi3.so`)
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`, `git-clone`, `ggshield-auth`, `ggshield-hook`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`, `git-clone`, `ggshield-auth`, `ggshield-hook`, `send`
 
 ## Important Timing Constraints
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -187,13 +187,16 @@ send() {
     echo "[send] ERROR: rclone remote 'onedrive' is not configured (run: rclone config)" >&2
     return 1
   fi
-  local target base dest
+  local target trimmed base dest
   for target in "$@"; do
     if [ ! -e "$target" ]; then
       echo "[send] ERROR: not found: $target" >&2
       return 1
     fi
-    base="${target:t}"
+    # strip a trailing slash so `send mydir/` still yields a non-empty basename via ${:t}
+    trimmed="${target%/}"
+    [ -z "$trimmed" ] && trimmed="$target"
+    base="${trimmed:t}"
     if [ -d "$target" ]; then
       dest="onedrive:Downloads/$base/"
     else

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -172,6 +172,41 @@ fi
 
 {{- if eq .chezmoi.os "android" }}
 alias top5size='du -hs * | sort -rh | head -5'
+
+# upload file(s)/dir(s) to the OneDrive "Downloads" folder via rclone (see .docs/rclone-onedrive-setup.md)
+send() {
+  if [ $# -eq 0 ]; then
+    echo "[send] ERROR: usage: send <file|dir> [file|dir ...]" >&2
+    return 1
+  fi
+  if ! command -v rclone >/dev/null 2>&1; then
+    echo "[send] ERROR: rclone is not installed" >&2
+    return 1
+  fi
+  if ! rclone listremotes 2>/dev/null | grep -q '^onedrive:$'; then
+    echo "[send] ERROR: rclone remote 'onedrive' is not configured (run: rclone config)" >&2
+    return 1
+  fi
+  local target base dest
+  for target in "$@"; do
+    if [ ! -e "$target" ]; then
+      echo "[send] ERROR: not found: $target" >&2
+      return 1
+    fi
+    base="${target:t}"
+    if [ -d "$target" ]; then
+      dest="onedrive:Downloads/$base/"
+    else
+      dest="onedrive:Downloads/"
+    fi
+    echo "[send] uploading: $target -> $dest" >&2
+    if ! rclone copy "$target" "$dest" --progress; then
+      echo "[send] ERROR: upload failed for $target" >&2
+      return 1
+    fi
+  done
+  echo "[send] done" >&2
+}
 {{- else }}
 alias top5size='sudo du -hs * | sort -rh | head -5'
 {{- end }}


### PR DESCRIPTION
Introduces a Termux-only `send <file|dir> [...]` function that uploads
files or directories to the OneDrive "Downloads" folder via rclone.
Directories preserve their basename in the destination path; files drop
into the folder root. Guards check for rclone presence and the
`onedrive:` remote so misconfigurations fail fast with clear messages.