### PR TITLE
chore(linux): install clang and resolve latest Go dynamically

### DIFF
--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -20,6 +20,7 @@ requirements=(
     "binutils"      # required by GVM (Go Version Manager)
     "bison"         # required by GVM (Go Version Manager)
     "gcc"           # required for many things and GVM
+    "clang"         # required by some Go/Rust/C toolchains as an alternative to gcc
     "make"          # required for many things and GVM
 )
 sudo apt install --no-install-recommends --yes "${requirements[@]}"
@@ -68,7 +69,15 @@ install_oh_my_zsh() {
 
 # https://github.com/moovweb/gvm?tab=readme-ov-file
 install_gvm() {
-    local go_version="go1.25.5"
+    # Query the latest stable Go release from the official endpoint.
+    # https://go.dev/VERSION?m=text returns a body whose first line is "goX.Y.Z".
+    local go_version
+    go_version="$(curl -fsSL https://go.dev/VERSION?m=text 2>/dev/null | head -n1 | tr -d '[:space:]')" || true
+    if [[ -z "$go_version" || "$go_version" != go* ]]; then
+        echo "[configure-deps] ERROR: failed to resolve latest Go version from https://go.dev/VERSION?m=text" >&2
+        return 1
+    fi
+    echo "[configure-deps] latest Go version resolved: $go_version" >&2
 
     if [[ ! -d "$HOME/.gvm" ]]; then
         bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -412,7 +412,7 @@ install_oh_my_zsh
 # change the default shell to zsh so that new terminal sessions start in zsh
 # sudo usermod is used to avoid an interactive password prompt from chsh
 sudo usermod --shell "$(which zsh)" "$USER"
-install_gvm
+install_gvm || exit 1
 install_kubectl
 install_krew
 install_terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `clang` to the Linux/WSL core requirements in `run_once_before_linux-002-install-dependencies.sh` so toolchains that prefer it over `gcc` (Go/Rust/C) have a compiler available
+
+### Changed
+
+- changed `install_gvm` in `run_once_before_linux-002-install-dependencies.sh` to resolve the latest stable Go version from `https://go.dev/VERSION?m=text` on every run instead of hardcoding `go1.25.5`
+
 ## [0.9.0] - 2026-04-19
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds `clang` to the Linux/WSL core requirements in `run_once_before_linux-002-install-dependencies.sh` so toolchains that prefer it over `gcc` have a compiler available (Android/Termux already installs `clang`).
- Changes `install_gvm` to resolve the latest stable Go version from `https://go.dev/VERSION?m=text` on every run, replacing the hardcoded `go1.25.5`. Errors out cleanly if the fetch fails.

## Test plan

- [ ] `make lint-shellcheck` passes on the modified script
- [ ] Fresh WSL run installs `clang` alongside `gcc`
- [ ] `install_gvm` prints `[configure-deps] latest Go version resolved: goX.Y.Z` and installs/uses that version via `gvm`
- [ ] Re-run is idempotent (skips when the resolved version is already installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)