### PR TITLE
fix(android): wrap terragrunt and terraform with termux-etc-seccomp

### DIFF
--- a/.chezmoiscripts/run_after_android-003-wrap-terra-clis.sh
+++ b/.chezmoiscripts/run_after_android-003-wrap-terra-clis.sh
@@ -1,0 +1,84 @@
+#!/data/data/com.termux/files/usr/bin/bash
+
+# Wraps `terragrunt` and `terraform` in ~/.local/bin so every caller (shell,
+# terra's exec.Command, scripts) routes through termux-etc-seccomp for /etc/
+# path redirection and SIGSYS (faccessat2) suppression on Android/Termux.
+#
+# Shell aliases like `terragruntw` don't help here because Go's
+# exec.Command bypasses shell aliasing, which is how `terra` launches
+# terragrunt under the hood.
+#
+# This is a `run_after_` (not `run_once_after_`) script so it re-applies on
+# every `chezmoi apply`. `terra update` periodically refreshes these binaries
+# and would otherwise clobber the wrapper script.
+
+set -eu
+
+BIN_DIR="$HOME/.local/bin"
+
+is_wrapper() {
+    [ -f "$1" ] && grep -q 'termux-etc-seccomp' "$1" 2>/dev/null
+}
+
+wrap_go_cli() {
+    name="$1"
+    target="$BIN_DIR/$name"
+    raw="$BIN_DIR/${name}_raw"
+
+    # Nothing to wrap if the CLI hasn't been installed yet.
+    if [ ! -e "$target" ] && [ ! -e "$raw" ]; then
+        return 0
+    fi
+
+    # Already wrapped: idempotent no-op.
+    if is_wrapper "$target"; then
+        return 0
+    fi
+
+    # If $target is a real binary (first install, or `terra update` clobbered
+    # the previous wrapper), promote it to ${name}_raw so the new wrapper can
+    # exec it.
+    if [ -f "$target" ]; then
+        mv -f "$target" "$raw"
+    fi
+
+    if [ ! -x "$raw" ]; then
+        echo "[${name}-wrapper] WARN: ${raw} missing or not executable; skipping wrap" >&2
+        return 0
+    fi
+
+    echo "[${name}-wrapper] creating ${name} in ~/.local/bin..." >&2
+
+    cat > "$target" <<WRAPPER_EOF
+#!/data/data/com.termux/files/usr/bin/bash
+
+# Wraps ${name} through termux-etc-seccomp for /etc/ path redirection and
+# SIGSYS (faccessat2) suppression on Android/Termux.
+
+export PATH="/data/data/com.termux/files/usr/bin\${PATH:+:\$PATH}"
+export USER="\${USER:-\$(id -un)}"
+
+RAW_BIN="\${HOME}/.local/bin/${name}_raw"
+
+if ! command -v termux-etc-seccomp >/dev/null 2>&1; then
+  echo "[${name}-wrapper] ERROR: termux-etc-seccomp is not installed or not in PATH." >&2
+  echo "[${name}-wrapper] Re-run 'chezmoi apply' to install Android dependencies, then try again." >&2
+  exit 1
+fi
+
+if [ ! -x "\$RAW_BIN" ]; then
+  echo "[${name}-wrapper] ERROR: \$RAW_BIN is missing or not executable." >&2
+  echo "[${name}-wrapper] Re-run 'chezmoi apply' so terra can reinstall ${name}." >&2
+  exit 1
+fi
+
+exec termux-etc-seccomp "\$RAW_BIN" "\$@"
+WRAPPER_EOF
+
+    chmod +x "$target"
+
+    echo "[${name}-wrapper] ${name} wrapper created successfully" >&2
+}
+
+wrap_go_cli terragrunt
+wrap_go_cli terraform

--- a/.chezmoiscripts/run_after_android-003-wrap-terra-clis.sh
+++ b/.chezmoiscripts/run_after_android-003-wrap-terra-clis.sh
@@ -12,9 +12,10 @@
 # every `chezmoi apply`. `terra update` periodically refreshes these binaries
 # and would otherwise clobber the wrapper script.
 
-set -eu
+set -euo pipefail
 
 BIN_DIR="$HOME/.local/bin"
+mkdir -p "$BIN_DIR"
 
 is_wrapper() {
     [ -f "$1" ] && grep -q 'termux-etc-seccomp' "$1" 2>/dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `terragrunt hcl format` and any other `terragrunt`/`terraform` call from `terra`, scripts, or non-aliased shells crashing with `SIGSYS` on Android/Termux — Go's `os/exec.LookPath` issues `faccessat2` which hits Android's seccomp trap before `termux-etc-seccomp`'s ptrace layer can rewrite it to `-ENOSYS` when the binary is invoked bare (the `terragruntw`/`terraformw` aliases only cover interactive shell use, not `exec.Command`); new `run_after_android-003-wrap-terra-clis.sh` idempotently renames `~/.local/bin/{terragrunt,terraform}` to `*_raw` and replaces them with shell wrappers that `exec termux-etc-seccomp` against the raw binary, and re-runs on every `chezmoi apply` so `terra update` overwrites are re-wrapped automatically
+
 ## [0.10.0] - 2026-04-20
 
 ### Added


### PR DESCRIPTION
## Summary

- `terragrunt hcl format` (and any bare `terragrunt` / `terraform` call) crashed with `SIGSYS` on Android/Termux whenever invoked outside the `terragruntw` / `terraformw` shell aliases — e.g. by `terra`'s `exec.Command(ctx, "terragrunt", ...)` in [`run_from_root_command.go:97,102`](https://github.com/rios0rios0/terra/blob/main/internal/domain/commands/run_from_root_command.go). Go's `os/exec.LookPath` issues `faccessat2`, which Android's seccomp filter traps before `termux-etc-seccomp`'s ptrace layer can rewrite it to `-ENOSYS`.
- Added `.chezmoiscripts/run_after_android-003-wrap-terra-clis.sh` that idempotently renames `~/.local/bin/{terragrunt,terraform}` to `*_raw` and replaces them with shell wrappers that `exec termux-etc-seccomp` against the raw binary. Every caller — shell, `terra`, scripts, `exec.Command` — now routes through the supervisor.
- Uses `run_after_` (not `run_once_after_`) so it re-wraps after `terra update` overwrites the wrapper binary.
- Mirrors the existing wrapper pattern already in place for `gh`, `op`, and `golangci-lint` on Termux.

## Test plan

- [ ] on Termux: `chezmoi apply`
- [ ] `ls -la ~/.local/bin/terragrunt*` shows `terragrunt` (shell script) + `terragrunt_raw` (Go binary)
- [ ] `ls -la ~/.local/bin/terraform*` shows `terraform` (shell script) + `terraform_raw` (Go binary)
- [ ] `terra` wrapper call for format works: `terra format` or `terragrunt hcl format` in an HCL directory — no `SIGSYS`
- [ ] `terraform --version` works natively on Termux
- [ ] idempotency: run `chezmoi apply` again, confirm no state churn (script short-circuits via `is_wrapper` check)
- [ ] after `terra update` (which reinstalls the binary over the wrapper), next `chezmoi apply` re-wraps cleanly