### PR TITLE
feat(acli): add Atlassian CLI install for Linux/WSL and Android

### DIFF
--- a/.chezmoiscripts/run_once_before_android-001d-create-acli-wrapper.sh
+++ b/.chezmoiscripts/run_once_before_android-001d-create-acli-wrapper.sh
@@ -1,0 +1,45 @@
+#!/data/data/com.termux/files/usr/bin/bash
+
+# This script creates the 'acli' wrapper before dependencies are installed.
+# Uses termux-etc-seccomp to redirect /etc/ paths and suppress SIGSYS from Android's
+# seccomp policy for the statically-compiled linux/arm64 acli (Atlassian CLI) binary.
+
+set -e
+
+echo "[acli-wrapper] creating acli in ~/.local/bin..." >&2
+
+cat > "$HOME/.local/bin/acli" << 'ACLI_EOF'
+#!/data/data/com.termux/files/usr/bin/bash
+
+# Wraps acli (Atlassian CLI) through termux-etc-seccomp for /etc/ path redirection
+# and SIGSYS suppression on Android/Termux.
+
+# Ensure Termux bin is in PATH so acli can find auxiliary tools.
+export PATH="/data/data/com.termux/files/usr/bin${PATH:+:$PATH}"
+
+# Go's user.Current() in GOOS=linux static binaries requires $USER when
+# /etc/passwd is missing (Android).
+export USER="${USER:-$(id -un)}"
+
+ACLI_BIN="${HOME}/.local/bin/acli_linux_arm64"
+
+# Ensure termux-etc-seccomp is available before exec.
+if ! command -v termux-etc-seccomp >/dev/null 2>&1; then
+  echo "[acli-wrapper] ERROR: termux-etc-seccomp is not installed or not in PATH." >&2
+  echo "[acli-wrapper] Re-run 'chezmoi apply' to install Android dependencies, then try again." >&2
+  exit 1
+fi
+
+# Ensure the underlying acli binary exists and is executable.
+if [ ! -x "${ACLI_BIN}" ]; then
+  echo "[acli-wrapper] ERROR: ${ACLI_BIN} is missing or not executable." >&2
+  echo "[acli-wrapper] Re-run 'chezmoi apply' so Android acli dependencies are installed." >&2
+  exit 1
+fi
+
+exec termux-etc-seccomp "${ACLI_BIN}" "$@"
+ACLI_EOF
+
+chmod +x "$HOME/.local/bin/acli"
+
+echo "[acli-wrapper] acli wrapper created successfully" >&2

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -365,7 +365,7 @@ install_acli() {
             chmod +x "$acliBin"
         )
     else
-        echo "Atlassian CLI is already installed."
+        echo "[acli] acli is already installed, skipping" >&2
     fi
 }
 

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -339,6 +339,31 @@ install_golangci_lint() {
     fi
 }
 
+# https://developer.atlassian.com/cloud/acli/guides/install-linux/
+install_acli() {
+    binPath="$HOME/.local/bin"
+    acliBin="$binPath/acli_linux_arm64"
+
+    if [ ! -f "$acliBin" ]; then
+        (
+            tmpDir="$(mktemp -d)" || {
+                echo "[acli] ERROR: failed to create temporary directory" >&2
+                exit 1
+            }
+
+            trap 'rm -rf "$tmpDir"' EXIT
+            cd "$tmpDir" || exit 1
+
+            wget "https://acli.atlassian.com/linux/latest/acli_linux_arm64.tar.gz" -O acli.tar.gz
+            tar -xzf acli.tar.gz
+            mv acli "$acliBin"
+            chmod +x "$acliBin"
+        )
+    else
+        echo "Atlassian CLI is already installed."
+    fi
+}
+
 # https://github.com/aws/aws-cli/tree/v2
 # Termux can't use the official aws-cli aarch64 bundle (glibc-linked; Termux is bionic),
 # so we build from source. `cmake`, `rust`, `clang`, and `make` in the deps above provide
@@ -462,6 +487,7 @@ install_github_copilot
 install_golangci_lint
 install_aws_cli
 install_azure_cli
+install_acli
 
 # =========================================================================================================
 # DNS configuration is handled by termux-etc-redirect's install.sh script,

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -340,6 +340,9 @@ install_golangci_lint() {
 }
 
 # https://developer.atlassian.com/cloud/acli/guides/install-linux/
+# Atlassian only publishes a rolling `latest` endpoint (no versioned URLs, no checksums/signatures),
+# so pinning or cryptographic verification is not possible upstream; the install tracks the latest
+# stable channel officially recommended by Atlassian.
 install_acli() {
     binPath="$HOME/.local/bin"
     acliBin="$binPath/acli_linux_arm64"
@@ -355,7 +358,9 @@ install_acli() {
             cd "$tmpDir" || exit 1
 
             wget "https://acli.atlassian.com/linux/latest/acli_linux_arm64.tar.gz" -O acli.tar.gz
-            tar -xzf acli.tar.gz
+            # The archive nests the binary under `acli_<version>-stable_linux_arm64/acli`,
+            # so strip the versioned top-level directory to extract the binary directly.
+            tar -xzf acli.tar.gz --strip-components=1
             mv acli "$acliBin"
             chmod +x "$acliBin"
         )

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -397,6 +397,38 @@ install_ggshield() {
     fi
 }
 
+# https://developer.atlassian.com/cloud/acli/guides/install-linux/
+install_acli() {
+    if command -v acli &>/dev/null; then
+        echo "[configure-deps] acli is already installed, skipping" >&2
+        return
+    fi
+
+    local arch
+    case "$(uname -m)" in
+        x86_64)          arch="amd64" ;;
+        aarch64 | arm64) arch="arm64" ;;
+        *)
+            echo "[acli] ERROR: unsupported architecture: $(uname -m)" >&2
+            return 1
+            ;;
+    esac
+
+    (
+        tmpDir="$(mktemp -d)" || {
+            echo "[acli] ERROR: failed to create temporary directory" >&2
+            exit 1
+        }
+
+        trap 'rm -rf "$tmpDir"' EXIT
+        cd "$tmpDir" || exit 1
+
+        curl -fsSL "https://acli.atlassian.com/linux/latest/acli_linux_${arch}.tar.gz" -o acli.tar.gz
+        tar -xzf acli.tar.gz
+        sudo install -m 0755 acli /usr/local/bin/acli
+    )
+}
+
 # https://www.speedtest.net/apps/cli
 install_speedtest_cli() {
     if command -v speedtest &>/dev/null; then
@@ -431,6 +463,8 @@ install_aws_cli
 install_azure_cli
 
 install_ggshield
+
+install_acli
 
 install_speedtest_cli
 # =========================================================================================================

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -398,6 +398,9 @@ install_ggshield() {
 }
 
 # https://developer.atlassian.com/cloud/acli/guides/install-linux/
+# Atlassian only publishes a rolling `latest` endpoint (no versioned URLs, no checksums/signatures),
+# so pinning or cryptographic verification is not possible upstream; the install tracks the latest
+# stable channel officially recommended by Atlassian.
 install_acli() {
     if command -v acli &>/dev/null; then
         echo "[configure-deps] acli is already installed, skipping" >&2
@@ -424,7 +427,9 @@ install_acli() {
         cd "$tmpDir" || exit 1
 
         curl -fsSL "https://acli.atlassian.com/linux/latest/acli_linux_${arch}.tar.gz" -o acli.tar.gz
-        tar -xzf acli.tar.gz
+        # The archive nests the binary under `acli_<version>-stable_linux_<arch>/acli`,
+        # so strip the versioned top-level directory to extract the binary directly.
+        tar -xzf acli.tar.gz --strip-components=1
         sudo install -m 0755 acli /usr/local/bin/acli
     )
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `acli` (Atlassian CLI) install to Linux/WSL via `install_acli` in `run_once_before_linux-002-install-dependencies.sh` (downloads `acli_linux_amd64.tar.gz`/`acli_linux_arm64.tar.gz` from `acli.atlassian.com` and installs to `/usr/local/bin`)
+- added `acli` (Atlassian CLI) install to Android/Termux via `install_acli` in `run_once_before_android-002-install-dependencies.sh.tmpl` (downloads `acli_linux_arm64.tar.gz` into `~/.local/bin/acli_linux_arm64`) plus `run_once_before_android-001d-create-acli-wrapper.sh` that generates a `termux-etc-seccomp` wrapper at `~/.local/bin/acli` so the Go-compiled binary survives Android's seccomp policy
+
 ## [0.10.1] - 2026-04-21
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,9 @@ The wrapper scripts follow a strict execution order:
 1. `android-001-create-wrapper.sh` — generic `termux-etc-seccomp` wrapper (all tool wrappers depend on this)
 2. `android-001a-create-op-wrapper.sh` — `op` wrapper (needed by chezmoi templates)
 3. `android-001b-create-gh-wrapper.sh` — `gh` wrapper (needed by install script for copilot)
-4. `android-002-install-dependencies.sh.tmpl` — installs binaries and extensions
+4. `android-001c-create-golangci-lint-wrapper.sh` — `golangci-lint` wrapper (backs the `golangci-lint_linux_arm64` binary installed in step 5)
+5. `android-001d-create-acli-wrapper.sh` — `acli` wrapper (backs the `acli_linux_arm64` binary installed in step 6)
+6. `android-002-install-dependencies.sh.tmpl` — installs binaries and extensions
 
 The generic `termux-etc-seccomp` wrapper is the only exception — it exists as BOTH a bootstrap script (for timing) AND a chezmoi-managed file (`dot_local/bin/executable_wrapper`) to keep it updated on subsequent applies.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`, `git-clone`, `ggshield-auth`, `ggshield-hook`, `send`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `git-sync`, `git-clone`, `ggshield-auth`, `ggshield-hook`, `acli`, `send`
 
 ## Important Timing Constraints
 


### PR DESCRIPTION
## Summary

- Installs [Atlassian CLI (`acli`)](https://developer.atlassian.com/cloud/acli/guides/install-linux/) on both **Linux/WSL** (`amd64`/`arm64`) and **Android/Termux** (`arm64`).
- Android gets a dedicated `termux-etc-seccomp` wrapper at `~/.local/bin/acli` so the Go-compiled binary survives the seccomp policy (same pattern used for `gh`, `op`, and `golangci-lint`).
- Windows intentionally omitted (Atlassian ships `acli` for Windows via MSI and this repo's Windows install flow uses `winget`/manual installers separately).

## Changes

- `run_once_before_linux-002-install-dependencies.sh` — new `install_acli` function; wired after `install_ggshield`.
- `run_once_before_android-002-install-dependencies.sh.tmpl` — new `install_acli` function; wired after `install_azure_cli`.
- `run_once_before_android-001d-create-acli-wrapper.sh` — new bootstrap script creating the seccomp wrapper before dependencies install.
- `CHANGELOG.md` — entry under `[Unreleased] > Added`.
- `CLAUDE.md` — `acli-wrapper` and `acli` prefixes added to the logging prefix reference list.

## Test plan

- [ ] `make lint` passes (shellcheck + Go template syntax verified locally)
- [ ] `make test` passes
- [ ] Fresh Linux run: `install_acli` downloads + installs `acli` to `/usr/local/bin`, `acli --version` returns
- [ ] Fresh Android run: `~/.local/bin/acli_linux_arm64` present; `acli --version` executes through `termux-etc-seccomp` without `SIGSYS`
- [ ] Re-run is idempotent (second apply skips with "already installed")