### PR TITLE
chore(ai-rules): removed install-ai-rules scripts in favor of aisync

### DIFF
--- a/.chezmoiscripts/run_after_android-002-install-ai-rules.sh.tmpl
+++ b/.chezmoiscripts/run_after_android-002-install-ai-rules.sh.tmpl
@@ -1,6 +1,0 @@
-#!{{ lookPath "bash" }}
-set -euo pipefail
-
-echo "[ai-rules] Installing AI rules from guide repository..."
-curl -fsSL https://raw.githubusercontent.com/rios0rios0/guide/generated/install-rules.sh | sh -s -- --force
-echo "[ai-rules] AI rules installed successfully."

--- a/.chezmoiscripts/run_after_linux-003-install-ai-rules.sh
+++ b/.chezmoiscripts/run_after_linux-003-install-ai-rules.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-echo "[ai-rules] Installing AI rules from guide repository..."
-curl -fsSL https://raw.githubusercontent.com/rios0rios0/guide/generated/install-rules.sh | sh -s -- --force
-echo "[ai-rules] AI rules installed successfully."

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -490,6 +490,25 @@ install_ruff() {
     python -m pipx install ruff
 }
 
+# https://github.com/rios0rios0/aisync
+# `aisync` syncs AI assistant rules/agents/skills across `~/.claude/`, `~/.cursor/`, etc.
+# It replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl
+# `install-rules.sh` from `rios0rios0/guide` on every chezmoi apply.
+# Uses Termux's native `golang` apt package (GVM is intentionally skipped on Android).
+install_aisync() {
+    if command_exists aisync; then
+        echo "[configure-deps] aisync is already installed, skipping" >&2
+        return
+    fi
+
+    if ! command_exists go; then
+        echo "[configure-deps] ERROR: go is not available; the 'golang' Termux package must be installed first" >&2
+        return 1
+    fi
+
+    go install github.com/rios0rios0/aisync/cmd/aisync@latest
+}
+
 install_oh_my_zsh
 
 # TODO: building Go versions on Termux are breaking, since they don't recognize system critical path (like /etc/resolv.conf) leading to DNS errors
@@ -516,6 +535,7 @@ install_golangci_lint
 install_aws_cli
 install_azure_cli
 install_ruff
+install_aisync
 install_acli
 
 # =========================================================================================================

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -418,6 +418,29 @@ install_ruff() {
     python -m pipx install ruff
 }
 
+# https://github.com/rios0rios0/aisync
+# `aisync` syncs AI assistant rules/agents/skills across `~/.claude/`, `~/.cursor/`, etc.
+# It replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl
+# `install-rules.sh` from `rios0rios0/guide` on every chezmoi apply.
+install_aisync() {
+    if command -v aisync &>/dev/null; then
+        echo "[configure-deps] aisync is already installed, skipping" >&2
+        return
+    fi
+
+    # Source GVM so `go` resolves to the version installed by `install_gvm`.
+    export GVM_ROOT="$HOME/.gvm"
+    # shellcheck source=/dev/null
+    [[ -s "$GVM_ROOT/scripts/gvm" ]] && source "$GVM_ROOT/scripts/gvm"
+
+    if ! command -v go &>/dev/null; then
+        echo "[configure-deps] ERROR: go is not available; install_gvm must run before install_aisync" >&2
+        return 1
+    fi
+
+    go install github.com/rios0rios0/aisync/cmd/aisync@latest
+}
+
 # https://developer.atlassian.com/cloud/acli/guides/install-linux/
 # Atlassian only publishes a rolling `latest` endpoint (no versioned URLs, no checksums/signatures),
 # so pinning or cryptographic verification is not possible upstream; the install tracks the latest
@@ -490,6 +513,7 @@ install_azure_cli
 
 install_ggshield
 install_ruff
+install_aisync
 
 install_acli
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,14 +130,12 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - `run_once_after_linux-002-clone-pentesting-tools.sh` — clones pentesting tools (VHostScan, dirsearch, StegCracker, stegbrute) to `~/Development/Tools/`
 - `run_once_after_windows-001-create-ssh-known-hosts.ps1` — pre-populates `~/.ssh/known_hosts` for GitHub, GitLab, Azure DevOps, Bitbucket (avoids SSH freeze in WSL)
 - `run_after_linux-002-import-gpg-keys.sh.tmpl` — imports GPG keys from 1Password (device note, `gpg:` entries)
-- `run_after_linux-003-install-ai-rules.sh` — installs AI assistant rule files into project directories
 - `run_after_linux-004-install-ggshield-hook.sh` — (re)generates the ggshield global pre-commit hook script; idempotent
 - `run_after_linux-005-install-jetbrains-themes.sh` — fans staged JetBrains themes into detected IDE config directories
 - `run_after_windows-001-create-ssh-public-keys.ps1.tmpl` — creates SSH public key files from 1Password (device note, `ssh:` entries)
 - `run_after_windows-002-create-ssh-pems.ps1.tmpl` — creates SSH PEM files on Windows (device note, `pem:` entries)
 - `run_after_windows-003-copy-app-data-files.ps1.tmpl` — copies files from `AppData/` in the repo to `~\AppData\` on Windows (directory names use `+` as wildcard for version-specific paths)
 - `run_after_android-001-create-ssh-keys.sh.tmpl` — creates SSH private/public key files from 1Password (device note, `ssh:` entries)
-- `run_after_android-002-install-ai-rules.sh.tmpl` — installs AI assistant rule files (Android)
 - `run_after_android-003-wrap-terra-clis.sh` — wraps terraform/terragrunt binaries with `termux-etc-seccomp` to avoid SIGSYS on Android
 - `run_after_windows-004-install-jetbrains-themes.ps1` — fans staged JetBrains themes into detected IDE config directories (Windows)
 
@@ -410,7 +408,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ai-rules`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`
 
 ## Security and Encryption
 - Private key location: `~/.ssh/chezmoi` (Linux/Windows) or via `op` wrapper (Android)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,6 +79,8 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
   - **GitHub CLI** (gh, via apt repository)
   - **Azure CLI** (via pip, installed into pyenv Python)
   - **ggshield** (GitGuardian CLI, via pipx) — installs a global pre-commit hook script at `~/.local/share/ggshield/git-hooks/pre-commit`; `core.hooksPath` in `~/.gitconfig` points all repos there
+  - **ruff** (Python linter, via pipx) — used by `make lint-python` to lint embedded Python in `modify_*` templates
+  - **aisync** ([`rios0rios0/aisync`](https://github.com/rios0rios0/aisync), via `go install`) — syncs AI assistant rules/agents/skills into `~/.claude/`, `~/.cursor/`, etc.; replaces the legacy `run_after_*-install-ai-rules.*` scripts
   - **Speedtest CLI** (Ookla, via packagecloud)
 - Each tool installation can take 5-15 minutes individually
 - **Critical**: Script requires internet access for downloading tools
@@ -96,7 +98,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - Installs Termux packages: git, curl, age, eza, sqlite, vim, neovim, zsh, proot, proot-distro, etc.
 - Sets up proot/Alpine wrapper for running Linux binaries natively
 - Installs: Oh My Zsh, GVM, terra (custom wrapper for terraform/terragrunt), kubectl (ARM64), SDKMAN, NVM, pyenv
-- Installs: Claude CLI, Gemini CLI, 1Password CLI (ARM64 binary), GitHub CLI, Azure CLI (via pip)
+- Installs: Claude CLI, Gemini CLI, 1Password CLI (ARM64 binary), GitHub CLI, Azure CLI (via pip), ruff (via pipx), aisync (via `go install`)
 - Configures NeoVim with AstroVim template (`~/.config/nvim`)
 - Configures Termux DNS (8.8.8.8, 8.8.4.4, 1.1.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added `install_ruff()` to Linux/WSL and Android dependency installers — provisions `ruff` via `pipx` so `make lint-python` works locally without a manual `pip install ruff` step (CI already installs `ruff` per the `validate.yaml` workflow)
+- added `install_aisync()` to Linux/WSL and Android dependency installers — `go install`s [`rios0rios0/aisync`](https://github.com/rios0rios0/aisync) so the `aisync` binary is available out of the box; this is the tool that took over from the removed `run_after_*-install-ai-rules.*` scripts and is run by the user (e.g., `aisync init`, `aisync source add guide …`, `aisync pull`) to sync AI assistant rules into `~/.claude/`, `~/.cursor/`, etc.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - changed log tags and inline comments in `dot_zshrc.tmpl`, `dot_scripts/linux-engineering-version-manager.sh`, `CLAUDE.md`, and `.github/copilot-instructions.md` to use the new project name
 - changed the chezmoi prefix listed in `CLAUDE.md` and `.github/copilot-instructions.md` from `devforge` to `dev-toolkit`
 
+### Removed
+
+- removed `run_after_linux-003-install-ai-rules.sh` and `run_after_android-002-install-ai-rules.sh.tmpl` since AI rules are now synced via `aisync` instead of being pulled from the guide repository at chezmoi-apply time
+
 ## [0.12.0] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ai-rules`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`
 
 ## Important Timing Constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,12 @@ Android 12+ includes a **Phantom Process Killer** that enforces a system-wide li
 
 **Manual Android settings:** Exclude Termux from battery optimization (`Unrestricted`), set animation scales to `0.5x`, enable RAM Plus if available.
 
+## AI Rules Sync
+
+AI assistant rules (Claude Code, Cursor, Codex, Gemini, etc.) are **not** managed by chezmoi. Directories like `~/.claude/`, `~/.cursor/`, `~/.codex/` are listed in `.chezmoiignore` and synced separately by [`aisync`](https://github.com/rios0rios0/aisync), a Go CLI installed by `install_aisync()` in the Linux/WSL and Android dependency scripts (replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl `install-rules.sh` from `rios0rios0/guide` on every apply).
+
+After the dependency installer finishes, run `aisync init`, `aisync source add guide --source-repo rios0rios0/guide --branch generated`, and `aisync pull` to populate the rules. Subsequent `aisync pull` calls refresh them on demand.
+
 ## Encryption Setup
 
 - Private key: `~/.ssh/chezmoi`


### PR DESCRIPTION
## Summary

- Removed `.chezmoiscripts/run_after_linux-003-install-ai-rules.sh` and `.chezmoiscripts/run_after_android-002-install-ai-rules.sh.tmpl`. These ran on every `chezmoi apply` and curl-piped `https://raw.githubusercontent.com/rios0rios0/guide/generated/install-rules.sh` to install AI rules into project directories.
- AI rules are now synced via `aisync`, so the chezmoi post-apply pull from the guide repository is redundant.
- Updated `CHANGELOG.md` (Unreleased > Removed), `CLAUDE.md`, and `.github/copilot-instructions.md` to drop references to the removed scripts and the now-unused `ai-rules` logging prefix.

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] `chezmoi apply --dry-run` no longer references `install-ai-rules`
- [ ] AI rules continue to be available via `aisync` on Linux and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)