### PR TITLE
chore(rename): rename devforge references to dev-toolkit

### DIFF
--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -252,7 +252,7 @@ install_dev_toolkit() {
         rm -f "$installer"
         if [ "$status" -ne 0 ]; then return "$status"; fi
     else
-        echo "Devforge is already installed."
+        echo "dev-toolkit is already installed."
     fi
 }
 

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -234,16 +234,16 @@ install_claude_cli() {
     npm install -g @anthropic-ai/claude-code
 }
 
-# https://github.com/rios0rios0/devforge
-install_devforge() {
+# https://github.com/rios0rios0/dev-toolkit
+install_dev_toolkit() {
     binPath="$HOME/.local/bin"
     devBin="$binPath/dev"
 
     if [ ! -f "$devBin" ]; then
         local installer
         installer="$(mktemp)"
-        if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh -o "$installer"; then
-            echo "[devforge] ERROR: failed to download installer" >&2
+        if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh -o "$installer"; then
+            echo "[dev-toolkit] ERROR: failed to download installer" >&2
             rm -f "$installer"
             return 1
         fi
@@ -481,7 +481,7 @@ install_sdkman
 install_nvm
 install_gemini_cli
 install_claude_cli
-install_devforge
+install_dev_toolkit
 
 # TODO: same of the line 261
 install_pyenv

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -467,6 +467,29 @@ install_azure_cli() {
     az extension add --name azure-devops
 }
 
+# https://docs.astral.sh/ruff/
+# Installed via pipx so it lives outside the active project's venv and is callable
+# from `make lint-python` regardless of the current pyenv/poetry shell context.
+install_ruff() {
+    if ! command_exists pip; then
+        echo "Install 'pip' first, it seems to be NOT installed..."
+
+        return;
+    fi
+
+    if ! python -m pip show pipx &>/dev/null; then
+        python -m pip install --upgrade pipx
+        python -m pipx ensurepath
+    fi
+
+    if python -m pipx list --short 2>/dev/null | grep -q '^ruff '; then
+        echo "[configure-deps] ruff is already installed, skipping" >&2
+        return
+    fi
+
+    python -m pipx install ruff
+}
+
 install_oh_my_zsh
 
 # TODO: building Go versions on Termux are breaking, since they don't recognize system critical path (like /etc/resolv.conf) leading to DNS errors
@@ -492,6 +515,7 @@ install_github_copilot
 install_golangci_lint
 install_aws_cli
 install_azure_cli
+install_ruff
 install_acli
 
 # =========================================================================================================

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -397,6 +397,27 @@ install_ggshield() {
     fi
 }
 
+# https://docs.astral.sh/ruff/
+# Installed via pipx so it lives outside the active project's venv and is callable
+# from `make lint-python` regardless of the current pyenv/poetry shell context.
+install_ruff() {
+    export PYENV_ROOT="$HOME/.pyenv"
+    export PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+
+    if ! python -m pip show pipx &>/dev/null; then
+        python -m pip install --upgrade pipx
+        python -m pipx ensurepath
+    fi
+
+    if python -m pipx list --short 2>/dev/null | grep -q '^ruff '; then
+        echo "[configure-deps] ruff is already installed, skipping" >&2
+        return
+    fi
+
+    python -m pipx install ruff
+}
+
 # https://developer.atlassian.com/cloud/acli/guides/install-linux/
 # Atlassian only publishes a rolling `latest` endpoint (no versioned URLs, no checksums/signatures),
 # so pinning or cryptographic verification is not possible upstream; the install tracks the latest
@@ -468,6 +489,7 @@ install_aws_cli
 install_azure_cli
 
 install_ggshield
+install_ruff
 
 install_acli
 

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -274,10 +274,10 @@ install_gemini_cli() {
     npm install -g @google/gemini-cli
 }
 
-# https://github.com/rios0rios0/devforge
-install_devforge() {
+# https://github.com/rios0rios0/dev-toolkit
+install_dev_toolkit() {
     if command -v dev &>/dev/null; then
-        echo "[configure-deps] devforge is already installed, skipping" >&2
+        echo "[configure-deps] dev-toolkit is already installed, skipping" >&2
         return
     fi
 
@@ -285,8 +285,8 @@ install_devforge() {
     local status
 
     installer="$(mktemp)"
-    if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/devforge/main/install.sh -o "$installer"; then
-        echo "[devforge] ERROR: failed to download installer" >&2
+    if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh -o "$installer"; then
+        echo "[dev-toolkit] ERROR: failed to download installer" >&2
         rm -f "$installer"
         return 1
     fi
@@ -461,7 +461,7 @@ install_pyenv
 install_cursor_cli
 install_claude_cli
 install_gemini_cli
-install_devforge
+install_dev_toolkit
 
 install_github_cli
 install_aws_cli

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -410,7 +410,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ai-rules`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `devforge`, `aws-cli`, `azure-cli`, `golangci-lint`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ai-rules`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`
 
 ## Security and Encryption
 - Private key location: `~/.ssh/chezmoi` (Linux/Windows) or via `op` wrapper (Android)
@@ -440,7 +440,7 @@ Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-key
    - kubectl, terraform, terragrunt available in PATH
    - Go (GVM), Node.js (NVM), Python (pyenv), Java (SDKMAN), Rust (Cargo) via version managers
    - Version managers auto-switch based on project files (`go.mod`, `.nvmrc`, `pyproject.toml`)
-   - Docker via devforge (`dev docker ips`, `dev docker reset`) and Kubernetes shortcuts configured
+   - Docker via dev-toolkit (`dev docker ips`, `dev docker reset`) and Kubernetes shortcuts configured
 
 4. **Security Setup**:
    - Age encryption working with private key at `~/.ssh/chezmoi`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- changed `devforge` references to `dev-toolkit` to match the upstream rename — install scripts now define `install_dev_toolkit()` and download from `https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh` (GitHub auto-redirects the old URL, but new installs use the renamed repository)
+- changed log tags and inline comments in `dot_zshrc.tmpl`, `dot_scripts/linux-engineering-version-manager.sh`, `CLAUDE.md`, and `.github/copilot-instructions.md` to use the new project name
+- changed the chezmoi prefix listed in `CLAUDE.md` and `.github/copilot-instructions.md` from `devforge` to `dev-toolkit`
+
 ## [0.12.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `install_ruff()` to Linux/WSL and Android dependency installers — provisions `ruff` via `pipx` so `make lint-python` works locally without a manual `pip install ruff` step (CI already installs `ruff` per the `validate.yaml` workflow)
+
 ### Changed
 
 - changed `devforge` references to `dev-toolkit` to match the upstream rename — install scripts now define `install_dev_toolkit()` and download from `https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh` (GitHub auto-redirects the old URL, but new installs use the renamed repository)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ai-rules`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `devforge`, `aws-cli`, `azure-cli`, `golangci-lint`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ai-rules`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`
 
 ## Important Timing Constraints
 

--- a/dot_scripts/linux-engineering-version-manager.sh
+++ b/dot_scripts/linux-engineering-version-manager.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Version Manager Utilities (pyenv workarounds only)
-# Version detection and switching migrated to devforge: `dev project use`
+# Version detection and switching migrated to dev-toolkit: `dev project use`
 #
 
 # Clean up stale pyenv shim locks (fixes rehash lock issues)

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -275,7 +275,7 @@ source "$HOME/.scripts/linux-engineering-detect-kube-config-files.sh"
 if command -v docker &>/dev/null; then
   zinit snippet "https://github.com/docker/cli/blob/master/contrib/completion/zsh/_docker"
 fi
-# docker aliases (dip, dreset) migrated to devforge: `dev docker ips`, `dev docker reset`
+# docker aliases (dip, dreset) migrated to dev-toolkit: `dev docker ips`, `dev docker reset`
 {{- end }}
 
 if [[ -o interactive ]]; then
@@ -358,7 +358,7 @@ if [[ -o interactive ]]; then
     fi
 
     # Auto-detect and switch to the required SDK version for the current directory
-    # Replaces _vm_use_go, _vm_use_node, _vm_use_python (migrated to devforge)
+    # Replaces _vm_use_go, _vm_use_node, _vm_use_python (migrated to dev-toolkit)
     eval "$(dev project use . 2>/dev/null)"
 fi # -o interactive
 


### PR DESCRIPTION
## Summary

Aligns this repository with the upstream rename of `rios0rios0/devforge` → `rios0rios0/dev-toolkit`. The reserved `forge` suffix is now used only for libraries (`gitforge`, `langforge`, `cliforge`), keeping the CLI named distinctly.

The installed binary is still `dev`, so end-user shell ergonomics are unchanged.

## Changes

- Linux and Android dependency-install scripts now define `install_dev_toolkit()` and download the installer from `https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh`. GitHub auto-redirects the old URL, so existing installs keep working.
- Log tags `[devforge]` → `[dev-toolkit]` in install script error paths.
- Inline comments in `dot_zshrc.tmpl`, `dot_scripts/linux-engineering-version-manager.sh`, and the docs (`CLAUDE.md`, `.github/copilot-instructions.md`) updated to use the new project name.
- Chezmoi prefix list entry renamed from `devforge` to `dev-toolkit`.
- Historical `CHANGELOG.md` entries (the original `devforge` integration) are preserved as-is. New `[Unreleased] > Changed` entries describe this rename.

## Companion PR

- rios0rios0/devforge#90 — the actual rename of the upstream repository.

## Test plan

- [x] `chezmoi diff` (manual) — verify install scripts apply with the new function name
- [x] No prefix-encoded `devforge` files exist; the chezmoi prefix list change is documentation-only
- [ ] After upstream rename merges, run `chezmoi apply` on a fresh device to verify the install URL resolves to the renamed repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)