### PR TITLE
fix(install-deps): harden Android installer and unify Go-tool installation

### DIFF
--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -58,6 +58,7 @@ utilities=(
     "which"             # it performs command lookups
     "mlocate"           # it performs file searches (locate and updatedb)
     "openssh"           # used to clone Git repositories and also authentication
+    "netcat-openbsd"    # provides `nc` (Termux ships no default), required by SSH `ProxyCommand` blocks in `dot_ssh/config.tmpl`
     "parallel"          # it runs many threads of a command at the same time
     "rsync"             # provides file sync function
     "rclone"            # it's for syncing files with cloud storage (OneDrive, Google Drive, S3, etc.)
@@ -81,6 +82,95 @@ apt install --no-install-recommends --yes "${languages[@]}"
 # =========================================================================================================
 command_exists() {
   command -v "$1" >/dev/null 2>&1
+}
+
+# Sync a clone to its origin's default branch.
+# `git pull --rebase` fails when the working branch has no upstream tracking
+# (e.g., the local clone is parked on a feature branch from previous work),
+# producing "There is no tracking information for the current branch".
+# Detect HEAD via `origin/HEAD`, check it out, then rebase against the remote.
+sync_repo_to_default() {
+    local repoPath="$1"
+
+    (
+        cd "$repoPath" || return 1
+
+        if ! git fetch --all --prune; then
+            echo "[sync-repo] WARN: git fetch failed in $repoPath; continuing with local state" >&2
+            return 0
+        fi
+
+        local defaultBranch
+        defaultBranch="$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+        if [ -z "$defaultBranch" ]; then
+            git remote set-head origin --auto >/dev/null 2>&1 || true
+            defaultBranch="$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+        fi
+        if [ -z "$defaultBranch" ]; then
+            defaultBranch="main"
+        fi
+
+        if ! git checkout "$defaultBranch"; then
+            echo "[sync-repo] WARN: failed to checkout $defaultBranch in $repoPath; skipping rebase" >&2
+            return 0
+        fi
+        git pull --rebase origin "$defaultBranch"
+    )
+}
+
+# Install a Go-based tool by cloning its repo and running `make install` with
+# Termux's native `golang` (apt) toolchain.
+#
+# Why source-build instead of fetching the upstream `install.sh` / release
+# tarball on Android: pre-built `linux-arm64` Go binaries are produced with
+# `GOOS=linux`, so at runtime they:
+#   1. Open Linux paths that don't exist under Termux's bionic layout —
+#      `/etc/resolv.conf`, `/etc/hosts`, `/etc/ssl/certs/...`, `/etc/passwd`
+#      (the last for `os/user.Current()`).
+#   2. Issue the `faccessat2(439)` syscall, which Android's seccomp policy
+#      blocks with `SIGSYS` ("bad system call").
+# Running them at all therefore requires wrapping every entrypoint with
+# `termux-etc-seccomp` (the LD_PRELOAD shim that redirects `/etc/*` to
+# `$PREFIX/etc/*` and suppresses `SIGSYS`). Building locally with the Termux
+# `golang` package produces `GOOS=android` binaries that already use bionic's
+# `getaddrinfo`, the Termux file paths, and avoid the blocked syscalls — so
+# they run unwrapped just like `aisync` always has. Same reasoning is encoded
+# in `install_gvm`'s comment block above.
+#
+# All three of our Go tools (`terra`, `dev-toolkit`, `aisync`) ship a `make
+# install` target, so a single helper covers them.
+#
+# Args:
+#   $1 — repository HTTPS URL (e.g. https://github.com/rios0rios0/terra.git)
+#   $2 — installed binary name (used both as the "already installed?" sentinel
+#        and as the friendly log prefix)
+install_go_tool_from_source() {
+    local repoUrl="$1"
+    local binaryName="$2"
+
+    if command_exists "$binaryName" || [ -x "$HOME/.local/bin/$binaryName" ]; then
+        echo "[$binaryName] already installed, skipping" >&2
+        return 0
+    fi
+
+    if ! command_exists go; then
+        echo "[$binaryName] ERROR: go is not available; the 'golang' Termux package must be installed first" >&2
+        return 1
+    fi
+
+    # Mirror the existing repo layout (e.g. ~/Development/github.com/owner/repo)
+    # so manual `cd` paths and earlier ad-hoc clones keep working.
+    local relPath
+    relPath="$(echo "$repoUrl" | sed -E 's@^https?://@@; s@\.git$@@')"
+    local sourcePath="$HOME/Development/$relPath"
+
+    mkdir -p "$(dirname "$sourcePath")"
+    if [ ! -d "$sourcePath" ]; then
+        git clone "$repoUrl" "$sourcePath"
+    fi
+    sync_repo_to_default "$sourcePath"
+
+    (cd "$sourcePath" && make install)
 }
 
 # https://ohmyz.sh/#install
@@ -112,9 +202,11 @@ install_termux_etc_redirect() {
       git clone https://github.com/rios0rios0/termux-etc-redirect.git "$sourcePath"
   fi
 
+  sync_repo_to_default "$sourcePath"
+
   # Run in a subshell to avoid changing the script's working directory
   (
-    cd "$sourcePath" && git fetch --all && git pull --rebase
+    cd "$sourcePath" || return 1
 
     # Build, install, and create missing config files (resolv.conf, nsswitch.conf)
     ./scripts/install.sh
@@ -124,23 +216,13 @@ install_termux_etc_redirect() {
 # github.com/rios0rios0/terra
 # https://terragrunt.gruntwork.io/docs/getting-started/install/
 # https://developer.hashicorp.com/terraform/install
+#
+# `terra update` itself fetches `terragrunt`/`terraform` as `GOOS=linux` blobs;
+# those *do* need wrapping and are handled by
+# `run_after_android-003-wrap-terra-clis.sh`. `terra` itself we build from
+# source so the launcher entrypoint stays unwrapped.
 install_terra() {
-    # TODO: can't avoid repetition?
-    binPath="$HOME/.local/bin"
-    terraBin="$binPath/terra"
-
-    if [ ! -f "$terraBin" ]; then
-        sourcePath="$HOME/Development/github.com/rios0rios0/terra"
-        if [ ! -d "$sourcePath" ]; then
-            git clone https://github.com/rios0rios0/terra.git "$sourcePath"
-        fi
-        cd "$sourcePath" && git fetch --all && git pull --rebase
-
-        make install
-    else
-        echo "Terra is already installed."
-    fi
-
+    install_go_tool_from_source https://github.com/rios0rios0/terra.git terra
     terra update
 }
 
@@ -232,24 +314,7 @@ install_gemini_cli() {
 
 # https://github.com/rios0rios0/dev-toolkit
 install_dev_toolkit() {
-    binPath="$HOME/.local/bin"
-    devBin="$binPath/dev"
-
-    if [ ! -f "$devBin" ]; then
-        local installer
-        installer="$(mktemp)"
-        if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/dev-toolkit/main/install.sh -o "$installer"; then
-            echo "[dev-toolkit] ERROR: failed to download installer" >&2
-            rm -f "$installer"
-            return 1
-        fi
-        bash "$installer"
-        local status=$?
-        rm -f "$installer"
-        if [ "$status" -ne 0 ]; then return "$status"; fi
-    else
-        echo "dev-toolkit is already installed."
-    fi
+    install_go_tool_from_source https://github.com/rios0rios0/dev-toolkit.git dev
 }
 
 # https://1password.com/downloads/command-line/
@@ -492,17 +557,7 @@ install_ruff() {
 # `install-rules.sh` from `rios0rios0/guide` on every chezmoi apply.
 # Uses Termux's native `golang` apt package (GVM is intentionally skipped on Android).
 install_aisync() {
-    if command_exists aisync; then
-        echo "[configure-deps] aisync is already installed, skipping" >&2
-        return
-    fi
-
-    if ! command_exists go; then
-        echo "[configure-deps] ERROR: go is not available; the 'golang' Termux package must be installed first" >&2
-        return 1
-    fi
-
-    go install github.com/rios0rios0/aisync/cmd/aisync@latest
+    install_go_tool_from_source https://github.com/rios0rios0/aisync.git aisync
 }
 
 install_oh_my_zsh

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -95,6 +95,20 @@ sync_repo_to_default() {
     (
         cd "$repoPath" || return 1
 
+        # Refuse to proceed if the directory exists but isn't actually a git
+        # working tree (e.g., a stale `~/Development/<owner>/<repo>` left over
+        # from a botched clone). Without this guard, `git fetch` below would
+        # fail, the WARN branch would treat it as a transient network issue,
+        # and the caller would happily run `make install` against a non-repo.
+        if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            echo "[sync-repo] ERROR: $repoPath is not a git working tree" >&2
+            return 1
+        fi
+
+        # Network failures (offline Termux, captive portal, …) are non-fatal:
+        # we keep going against the local state so the caller can still build
+        # a previously-cloned tree. The non-git case above is the one that
+        # must hard-fail.
         if ! git fetch --all --prune; then
             echo "[sync-repo] WARN: git fetch failed in $repoPath; continuing with local state" >&2
             return 0
@@ -168,7 +182,10 @@ install_go_tool_from_source() {
     if [ ! -d "$sourcePath" ]; then
         git clone "$repoUrl" "$sourcePath"
     fi
-    sync_repo_to_default "$sourcePath"
+    if ! sync_repo_to_default "$sourcePath"; then
+        echo "[$binaryName] ERROR: failed to sync $sourcePath to its default branch; aborting build" >&2
+        return 1
+    fi
 
     (cd "$sourcePath" && make install)
 }

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -141,34 +141,40 @@ install_krew() {
     kubectl krew install ns
 }
 
-# https://developer.hashicorp.com/terraform/install
-install_terraform() {
-    if command -v terraform &>/dev/null; then
-        echo "[configure-deps] terraform is already installed, skipping" >&2
-        return
-    fi
-
-    wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --yes --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com bullseye main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-    sudo apt update && sudo apt install terraform
-}
-
+# https://github.com/rios0rios0/terra
 # https://terragrunt.gruntwork.io/docs/getting-started/install/
-install_terragrunt() {
-    local target_version="v0.76.6"
+# https://developer.hashicorp.com/terraform/install
+#
+# `terra` is the cross-platform launcher that pins and fetches the matching
+# `terraform`/`terragrunt` versions per project. Letting it own the install
+# replaces the previous one-off `install_terraform` (HashiCorp apt repo) and
+# `install_terragrunt` (direct GitHub release download) functions and keeps
+# Linux/WSL aligned with Android, where this has always been the only path.
+# `terra update` itself downloads the matching `terraform`/`terragrunt`
+# binaries; on Linux they are vanilla `GOOS=linux` Go executables that run
+# natively under glibc, so no `termux-etc-seccomp`-style wrapping is needed
+# (that part is Android-only and lives in `run_after_android-003-wrap-terra-clis.sh`).
+install_terra() {
+    if command -v terra &>/dev/null; then
+        echo "[configure-deps] terra is already installed, skipping" >&2
+    else
+        local installer
+        local status
 
-    if command -v terragrunt &>/dev/null; then
-        local current_version
-        current_version="$(terragrunt --version 2>/dev/null | grep -oP 'v[\d.]+')" || true
-        if [[ "$current_version" == "$target_version" ]]; then
-            echo "[configure-deps] terragrunt $target_version is already installed, skipping" >&2
-            return
+        installer="$(mktemp)"
+        if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/terra/main/install.sh -o "$installer"; then
+            echo "[terra] ERROR: failed to download installer" >&2
+            rm -f "$installer"
+            return 1
         fi
+
+        sh "$installer"
+        status=$?
+        rm -f "$installer"
+        if [ "$status" -ne 0 ]; then return "$status"; fi
     fi
 
-    curl -LO "https://github.com/gruntwork-io/terragrunt/releases/download/${target_version}/terragrunt_linux_amd64"
-    sudo mv terragrunt_linux_amd64 /usr/local/bin/terragrunt
-    sudo chmod +x /usr/local/bin/terragrunt
+    terra update
 }
 
 # https://sdkman.io/install/
@@ -422,23 +428,33 @@ install_ruff() {
 # `aisync` syncs AI assistant rules/agents/skills across `~/.claude/`, `~/.cursor/`, etc.
 # It replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl
 # `install-rules.sh` from `rios0rios0/guide` on every chezmoi apply.
+#
+# On Linux/WSL we fetch the upstream `install.sh` (same shape as
+# `install_dev_toolkit` and what `terra` ships) instead of `go install`-ing from
+# source. The pre-built `linux-<arch>` Go binary runs natively under glibc — no
+# Termux-style `/etc/*` redirection or seccomp suppression is needed — and
+# avoids requiring a working `go` toolchain on this host.
 install_aisync() {
     if command -v aisync &>/dev/null; then
         echo "[configure-deps] aisync is already installed, skipping" >&2
         return
     fi
 
-    # Source GVM so `go` resolves to the version installed by `install_gvm`.
-    export GVM_ROOT="$HOME/.gvm"
-    # shellcheck source=/dev/null
-    [[ -s "$GVM_ROOT/scripts/gvm" ]] && source "$GVM_ROOT/scripts/gvm"
+    local installer
+    local status
 
-    if ! command -v go &>/dev/null; then
-        echo "[configure-deps] ERROR: go is not available; install_gvm must run before install_aisync" >&2
+    installer="$(mktemp)"
+    if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/aisync/main/install.sh -o "$installer"; then
+        echo "[aisync] ERROR: failed to download installer" >&2
+        rm -f "$installer"
         return 1
     fi
 
-    go install github.com/rios0rios0/aisync/cmd/aisync@latest
+    bash "$installer"
+    status=$?
+    rm -f "$installer"
+
+    return "$status"
 }
 
 # https://developer.atlassian.com/cloud/acli/guides/install-linux/
@@ -496,8 +512,7 @@ sudo usermod --shell "$(which zsh)" "$USER"
 install_gvm || exit 1
 install_kubectl
 install_krew
-install_terraform
-install_terragrunt
+install_terra
 install_sdkman
 install_nvm
 install_pyenv

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -163,7 +163,7 @@ install_terra() {
 
         installer="$(mktemp)"
         if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/terra/main/install.sh -o "$installer"; then
-            echo "[terra] ERROR: failed to download installer" >&2
+            echo "[configure-deps] ERROR: failed to download terra installer" >&2
             rm -f "$installer"
             return 1
         fi
@@ -445,7 +445,7 @@ install_aisync() {
 
     installer="$(mktemp)"
     if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/aisync/main/install.sh -o "$installer"; then
-        echo "[aisync] ERROR: failed to download installer" >&2
+        echo "[configure-deps] ERROR: failed to download aisync installer" >&2
         rm -f "$installer"
         return 1
     fi

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -168,7 +168,7 @@ install_terra() {
             return 1
         fi
 
-        sh "$installer"
+        bash "$installer"
         status=$?
         rm -f "$installer"
         if [ "$status" -ne 0 ]; then return "$status"; fi

--- a/.github/ci/fixtures/mock-op.sh
+++ b/.github/ci/fixtures/mock-op.sh
@@ -1,6 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 # Mock 1Password CLI for CI testing
 # Returns deterministic JSON fixtures based on the command and arguments
+#
+# POSIX `sh` (not `bash`): chezmoi fork/exec's this script during
+# `make test-template-render`, so the kernel reads the shebang directly.
+# Termux has `/bin/sh` (Android's mksh) and `/data/data/com.termux/files/usr/bin/bash`,
+# but no `/bin/bash` or `/usr/bin/env`. CI's Linux runner has `/bin/sh -> dash`.
+# Sticking to POSIX (`[ ]`, `=`, no arrays) keeps this fixture executable on both.
 
 FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -8,7 +14,7 @@ FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
 echo "[mock-op] called with: $*" >&2
 
 # Strip --session flag and its value (chezmoi passes this after signin)
-while [[ "${1:-}" == --session ]]; do
+while [ "${1:-}" = "--session" ]; do
     shift 2
 done
 
@@ -24,14 +30,14 @@ case "$CMD" in
             get)
                 # Skip flags (--format, --vault, --account) to find the positional item name
                 ITEM_NAME=""
-                while [[ $# -gt 0 ]]; do
+                while [ $# -gt 0 ]; do
                     case "$1" in
                         --format|--vault|--account)
                             shift
-                            [[ $# -gt 0 ]] && shift
+                            [ $# -gt 0 ] && shift
                             ;;
                         *)
-                            if [[ -z "$ITEM_NAME" ]]; then
+                            if [ -z "$ITEM_NAME" ]; then
                                 ITEM_NAME="$1"
                             fi
                             shift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Fixed
 
 - fixed `install_termux_etc_redirect` in the Android dependency installer crashing with "There is no tracking information for the current branch" when the local clone was parked on a feature branch — extracted a `sync_repo_to_default` helper that fetches `origin`, resolves the upstream default branch via `refs/remotes/origin/HEAD` (with a `git remote set-head origin --auto` fallback and a final `main` fallback), checks it out, and rebases against `origin/<default>` before running the build/install step
+- fixed `make test-template-render` failing on Termux with `fork/exec …/mock-op.sh: no such file or directory` — the fixture had a `#!/bin/bash` shebang that the kernel can't resolve on Termux (no `/bin/bash`, no `/usr/bin/env`). Rewrote `.github/ci/fixtures/mock-op.sh` to POSIX `sh` (`#!/bin/sh`, `[ ]` and `=` instead of `[[ ]]` and `==`) so it runs on Termux's `/bin/sh` (Android's mksh) and CI's Linux `/bin/sh -> dash` equally well
 
 ## [0.13.0] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `netcat-openbsd` to the Android `requirements` list in `run_once_before_android-002-install-dependencies.sh.tmpl` so the SSH `ProxyCommand` blocks in `dot_ssh/config.tmpl` (`nc -z -w 5 …` fallback to `ssh.github.com:443`/`altssh.gitlab.com:443`/`altssh.bitbucket.org:443`) work out of the box on Termux, where `nc` is otherwise unavailable
+- added a shared `install_go_tool_from_source` helper in the Android dependency installer that clones a Go repo into `~/Development/<host>/<owner>/<repo>`, syncs to its default branch via `sync_repo_to_default`, and runs `make install`. Inline comment documents why source-build is mandatory on Android: pre-built `GOOS=linux` Go binaries open Linux-only paths (`/etc/resolv.conf`, `/etc/hosts`, `/etc/ssl/certs/...`, `/etc/passwd`) and use the `faccessat2(439)` syscall blocked by Android's seccomp policy, so they would otherwise need `termux-etc-seccomp` wrapping; building locally with the Termux `golang` apt package produces `GOOS=android` binaries that run unwrapped
+
+### Changed
+
+- changed Android `install_terra`, `install_dev_toolkit`, and `install_aisync` to all delegate to the new `install_go_tool_from_source` helper for one consistent source-build pattern. `install_terra` reverts to clone + `make install` (was briefly switched to `install.sh` in this same release cycle), `install_dev_toolkit` drops the `curl … install.sh | bash` fetch, and `install_aisync` drops `go install …@latest`
+- changed Linux/WSL `install_aisync` to fetch the upstream `https://raw.githubusercontent.com/rios0rios0/aisync/main/install.sh` (mirroring `install_dev_toolkit`) instead of `go install`-ing from source — pre-built `GOOS=linux` Go binaries run natively under glibc with no `/etc/*` redirection needed, and this drops the requirement for a working `go` toolchain on the install host
+- changed Linux/WSL to install `terra` (via the upstream `install.sh` from `rios0rios0/terra`) and let `terra update` provision `terraform`/`terragrunt`, replacing the standalone `install_terraform` (which added the HashiCorp apt repo + `apt install terraform`) and `install_terragrunt` (which `curl`-ed `terragrunt_linux_amd64` from a pinned Gruntwork release into `/usr/local/bin`). This brings Linux/WSL in line with Android (where `terra` has always been the only path) so per-project `terraform`/`terragrunt` versions are managed identically across platforms; on Linux the binaries `terra update` downloads run natively under glibc and need none of the `termux-etc-seccomp` wrapping that `run_after_android-003-wrap-terra-clis.sh` applies on Android
+
+### Fixed
+
+- fixed `install_termux_etc_redirect` in the Android dependency installer crashing with "There is no tracking information for the current branch" when the local clone was parked on a feature branch — extracted a `sync_repo_to_default` helper that fetches `origin`, resolves the upstream default branch via `refs/remotes/origin/HEAD` (with a `git remote set-head origin --auto` fallback and a final `main` fallback), checks it out, and rebases against `origin/<default>` before running the build/install step
+
 ## [0.13.0] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Added
 
-- added `netcat-openbsd` to the Android `requirements` list in `run_once_before_android-002-install-dependencies.sh.tmpl` so the SSH `ProxyCommand` blocks in `dot_ssh/config.tmpl` (`nc -z -w 5 …` fallback to `ssh.github.com:443`/`altssh.gitlab.com:443`/`altssh.bitbucket.org:443`) work out of the box on Termux, where `nc` is otherwise unavailable
+- added `netcat-openbsd` to the Android `utilities` array in `run_once_before_android-002-install-dependencies.sh.tmpl` so the SSH `ProxyCommand` blocks in `dot_ssh/config.tmpl` (`nc -z -w 5 …` fallback to `ssh.github.com:443`/`altssh.gitlab.com:443`/`altssh.bitbucket.org:443`) work out of the box on Termux, where `nc` is otherwise unavailable
 - added a shared `install_go_tool_from_source` helper in the Android dependency installer that clones a Go repo into `~/Development/<host>/<owner>/<repo>`, syncs to its default branch via `sync_repo_to_default`, and runs `make install`. Inline comment documents why source-build is mandatory on Android: pre-built `GOOS=linux` Go binaries open Linux-only paths (`/etc/resolv.conf`, `/etc/hosts`, `/etc/ssl/certs/...`, `/etc/passwd`) and use the `faccessat2(439)` syscall blocked by Android's seccomp policy, so they would otherwise need `termux-etc-seccomp` wrapping; building locally with the Termux `golang` apt package produces `GOOS=android` binaries that run unwrapped
 
 ### Changed


### PR DESCRIPTION
## Summary

Two Android `chezmoi apply` regressions plus a cross-platform consistency pass on how the in-house Go tools (`terra`, `dev-toolkit`, `aisync`) are installed.

## Bug fixes (Android)

- **Missing `nc` breaks SSH** — `dot_ssh/config.tmpl` uses `ProxyCommand sh -c 'nc -z -w 5 %h %p … || exec nc ssh.github.com 443'` for the port-22 → 443 fallback. Termux ships no default `nc`, so the proxy command silently failed with `sh: 1: exec: nc: not found` and `git pull` over SSH was unusable until the user ran `apt install netcat-openbsd` manually. Added `netcat-openbsd` to the `utilities` array so it's installed before any chezmoi-managed file references `nc`.
- **`install_termux_etc_redirect` crashes when the local clone is on a feature branch** — the script did `cd … && git fetch --all && git pull --rebase`. When the user has the repo parked on a feature branch with no upstream tracking (e.g. `feat/seccomp-reentrancy-guard`), `git pull --rebase` exits with *"There is no tracking information for the current branch"*. Extracted a new `sync_repo_to_default` helper that fetches `origin`, resolves the upstream default branch via `refs/remotes/origin/HEAD` (with `git remote set-head origin --auto` and a final `main` fallback), checks it out, and rebases against `origin/<default>` before the build/install step.

## Cross-platform unification (Go tools)

There are three rios0rios0 Go binaries the dotfiles install: `terra`, `dev-toolkit` (`dev`), and `aisync`. The way each was installed differed across platforms and across tools, and one combination was actually broken on Android.

**Why the platforms split:** pre-built `GOOS=linux` Go binaries try to read `/etc/resolv.conf`, `/etc/hosts`, `/etc/ssl/certs/...`, `/etc/passwd` (the last for `os/user.Current()`) and use the `faccessat2(439)` syscall blocked by Android's seccomp policy with `SIGSYS`. To run them on Termux you have to wrap every entrypoint with `termux-etc-seccomp` (the LD_PRELOAD shim that redirects `/etc/*` → `\$PREFIX/etc/*` and suppresses `SIGSYS`) — see `run_after_android-003-wrap-terra-clis.sh` for `terragrunt`/`terraform`. Building locally with the Termux `golang` apt package produces `GOOS=android` binaries that skip both problems.

So:

- **Android** → all three are now built from source via a new `install_go_tool_from_source` helper that clones to `~/Development/<host>/<owner>/<repo>`, syncs to the default branch, and runs `make install`. Header comment in the source explains the GOOS reasoning so the next contributor doesn't repeat my mistake.
- **Linux/WSL** → all three use the upstream `install.sh` (`install_dev_toolkit` already did, `install_aisync` switched from `go install …@latest`, `install_terra` is new). Pre-built `GOOS=linux` binaries run natively under glibc with no wrapping needed.

**Linux `terraform`/`terragrunt` simplification:** standalone `install_terraform` (added the HashiCorp apt repo and `apt install terraform`) and `install_terragrunt` (`curl`-ed a pinned `terragrunt_linux_amd64` from the Gruntwork release into `/usr/local/bin`) are gone. Linux now installs `terra` and lets `terra update` provision both, matching what Android has always done. Per-project versions of `terraform`/`terragrunt` are now managed identically on both platforms.

## File-level changes

- `.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl`: `+netcat-openbsd`, new helpers `sync_repo_to_default` and `install_go_tool_from_source`, three `install_*` functions collapsed to one-liners delegating to the helper.
- `.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh`: `install_terraform` + `install_terragrunt` removed; `install_terra` added (upstream `install.sh` + `terra update`); `install_aisync` switched from `go install` to upstream `install.sh`.
- `CHANGELOG.md`: `[Unreleased]` entries under `Added`, `Changed`, `Fixed`.

## Migration note for existing Linux/WSL hosts

Hosts that ran the old Linux installer have these orphans (not cleaned up by this PR — none of them break anything because `terra` puts its managed binaries in `~/.local/bin`, which is earlier on `PATH`):

- `/etc/apt/sources.list.d/hashicorp.list`
- `/usr/share/keyrings/hashicorp-archive-keyring.gpg`
- HashiCorp's apt-installed `terraform`
- `/usr/local/bin/terragrunt` (pinned `v0.76.6`)

Manual cleanup if desired:

```bash
sudo rm -f /etc/apt/sources.list.d/hashicorp.list /usr/share/keyrings/hashicorp-archive-keyring.gpg /usr/local/bin/terragrunt
sudo apt remove --purge terraform && sudo apt update
```

## Test plan

- [x] `make lint-shellcheck` — passes
- [x] `make lint-templates` — 29/29 templates parsed
- [x] `make test-chezmoiignore` — passes for linux/windows/android
- [x] `make test-script-order` — passes for all platforms
- [ ] `make test-template-render` — fails locally because the `mock-op.sh` fixture's `#!/bin/bash` shebang doesn't exist on Termux; pre-existing infra issue unrelated to this PR (CI runs on real Linux and is unaffected)
- [ ] Run `chezmoi apply` on a fresh Termux session and confirm `terra`, `dev`, and `aisync` install via the helper without needing `termux-etc-seccomp` wrapping
- [ ] Run `chezmoi apply` on a Linux/WSL host and confirm `terra update` provisions working `terraform`/`terragrunt`
- [ ] Verify SSH `ProxyCommand` works on a fresh Termux (i.e. `nc` is resolved and the port-22 → 443 fallback round-trips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)