### PR TITLE
fix(install): harden dependency installers against transient and stale-version failures

### DIFF
--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -242,7 +242,11 @@ install_termux_etc_redirect() {
 # source so the launcher entrypoint stays unwrapped.
 install_terra() {
     install_go_tool_from_source https://github.com/rios0rios0/terra.git terra
-    terra update
+    # On Android we build terra from source, so `terra self-update` is not
+    # appropriate — the source repo is the canonical version. `-a=y` keeps
+    # `terra update` non-interactive when newer terraform/terragrunt blobs
+    # are available.
+    terra -a=y update
 }
 
 # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -116,6 +116,26 @@ install_kubectl() {
 }
 
 # https://krew.sigs.k8s.io/docs/user-guide/setup/install/
+#
+# `kubectl krew` fetches its plugin index from `kubernetes-sigs/krew-index` on
+# every operation. GitHub occasionally returns HTTP 500 for this repo, which
+# fails `update`/`upgrade`/`install`. We retry a few times and treat persistent
+# failures as non-fatal so a transient outage doesn't break `chezmoi apply`.
+krew_retry() {
+    local max_attempts=3
+    local attempt=1
+    while (( attempt <= max_attempts )); do
+        if kubectl krew "$@"; then
+            return 0
+        fi
+        echo "[configure-deps] WARN: 'kubectl krew $*' failed (attempt ${attempt}/${max_attempts})" >&2
+        attempt=$(( attempt + 1 ))
+        (( attempt <= max_attempts )) && sleep 5
+    done
+    echo "[configure-deps] WARN: 'kubectl krew $*' failed after ${max_attempts} attempts; continuing" >&2
+    return 0
+}
+
 install_krew() {
     if [[ -d "${KREW_ROOT:-$HOME/.krew}" ]] && command -v kubectl-krew &>/dev/null; then
         echo "[configure-deps] krew is already installed, skipping download" >&2
@@ -135,10 +155,10 @@ install_krew() {
     export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
     # Upgrade krew itself and all installed plugins to the latest release
-    kubectl krew upgrade
+    krew_retry upgrade
 
-    kubectl krew install ctx
-    kubectl krew install ns
+    krew_retry install ctx
+    krew_retry install ns
 }
 
 # https://github.com/rios0rios0/terra
@@ -174,7 +194,14 @@ install_terra() {
         if [ "$status" -ne 0 ]; then return "$status"; fi
     fi
 
-    terra update
+    # Keep terra itself up to date — `terra update` only refreshes
+    # terraform/terragrunt and emits a warning when a newer terra exists.
+    # `--force` skips the interactive prompt.
+    terra self-update --force || echo "[configure-deps] WARN: terra self-update failed; continuing" >&2
+
+    # `-a=y` auto-answers the y/N prompts when newer terraform/terragrunt
+    # versions are detected, so unattended `chezmoi apply` runs don't hang.
+    terra -a=y update
 }
 
 # https://sdkman.io/install/
@@ -189,6 +216,16 @@ install_sdkman() {
     export SDKMAN_DIR="$HOME/.sdkman"
     # shellcheck source=/dev/null
     [[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"
+
+    # SDKMAN writes download headers/post-install hooks to `$SDKMAN_DIR/tmp`
+    # before running curl. The directory occasionally goes missing (e.g. after
+    # a manual cleanup) and `sdk install` fails with
+    # "curl: Failed to open .../*.headers.tmp". Recreate it defensively.
+    mkdir -p "$SDKMAN_DIR/tmp"
+
+    # Keep SDKMAN itself up to date so candidate metadata (new Java/Gradle
+    # versions, broker URLs) refreshes on every apply.
+    sdk selfupdate force >/dev/null 2>&1 || echo "[configure-deps] WARN: sdk selfupdate failed; continuing" >&2
 
     sdk install java
     sdk install gradle
@@ -392,7 +429,10 @@ install_ggshield() {
     fi
 
     if python -m pipx list --short 2>/dev/null | grep -q '^ggshield '; then
-        echo "[configure-deps] ggshield is already installed, skipping" >&2
+        # ggshield prints "A new version of ggshield has been released" on
+        # every invocation when out of date. Auto-upgrade keeps it current.
+        echo "[configure-deps] ggshield is already installed, upgrading via pipx" >&2
+        python -m pipx upgrade ggshield || echo "[configure-deps] WARN: pipx upgrade ggshield failed; continuing" >&2
     else
         python -m pipx install ggshield
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- hardened `install_krew` in `run_once_before_linux-002-install-dependencies.sh` with a new `krew_retry` helper that retries `kubectl krew upgrade`/`install` up to three times and treats persistent failures as non-fatal, so transient HTTP `500`s from the `kubernetes-sigs/krew-index` repository (e.g. `remote: Internal Server Error` during index fetch) no longer break `chezmoi apply`
+- changed `install_terra` in `run_once_before_linux-002-install-dependencies.sh` to call `terra self-update --force` followed by `terra -a=y update` so terra itself, `terraform`, and `terragrunt` upgrade non-interactively when newer versions are detected (previously `terra update` only refreshed `terraform`/`terragrunt` and printed `WARN: A new version of terra is available`, leaving terra itself stuck on the installed version, and the y/N prompts blocked unattended runs)
+- updated `install_terra` in `run_once_before_android-002-install-dependencies.sh.tmpl` to pass `-a=y` to `terra update` so the y/N prompts for newer `terraform`/`terragrunt` blobs auto-answer on Android (terra itself is built from source, so `terra self-update` is intentionally not invoked)
+- hardened `install_sdkman` in `run_once_before_linux-002-install-dependencies.sh` to recreate `$SDKMAN_DIR/tmp` before `sdk install` (preventing `curl: Failed to open .../*.headers.tmp` when SDKMAN's tmp directory has been cleared) and to run `sdk selfupdate force` so candidate metadata stays current
+- updated `install_ggshield` in `run_once_before_linux-002-install-dependencies.sh` to run `python -m pipx upgrade ggshield` when ggshield is already present, so a new GitGuardian release no longer prints `A new version of ggshield (vX.Y.Z) has been released` on every commit hook invocation
+
 ## [0.14.0] - 2026-05-03
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes four classes of noisy/blocking errors observed during `chezmoi update`:

- **krew HTTP 500** — `kubectl krew upgrade`/`install` was failing with `remote: Internal Server Error` while fetching `kubernetes-sigs/krew-index`. Added a `krew_retry` helper (3 attempts, 5s backoff) that treats persistent failures as non-fatal so a transient GitHub outage does not break `chezmoi apply`.
- **terra never self-updates** — `terra update` only refreshes `terraform`/`terragrunt` and prints `WARN: A new version of terra is available` indefinitely, while the y/N prompts blocked unattended runs. Added `terra self-update --force` (Linux only — Android builds terra from source) and `terra -a=y update` on both platforms.
- **SDKMAN missing tmp dir** — `sdk install java` failed with `curl: Failed to open .../*.headers.tmp` because `~/.sdkman/tmp` had been cleared. Now recreated defensively, plus `sdk selfupdate force` so candidate metadata stays current.
- **ggshield never upgrades** — once installed, `pipx install` is skipped forever so every commit hook prints `A new version of ggshield (vX.Y.Z) has been released`. Now runs `pipx upgrade ggshield` on the existing-install path.

## Test plan

- [x] `make lint-shellcheck` passes
- [x] `make lint-templates` passes
- [ ] Run `chezmoi apply` on Linux (WSL) and confirm the krew/terra/SDKMAN/ggshield blocks no longer print the noisy errors above
- [ ] Run `chezmoi apply` on Android (Termux) and confirm `terra -a=y update` no longer hangs on the y/N prompts