### PR TITLE
fix(terra-wrapper): replace sigsys_launcher chain with single termux-etc-seccomp call

### DIFF
--- a/.chezmoiscripts/run_after_android-003-wrap-terra-clis.sh
+++ b/.chezmoiscripts/run_after_android-003-wrap-terra-clis.sh
@@ -18,7 +18,10 @@ BIN_DIR="$HOME/.local/bin"
 mkdir -p "$BIN_DIR"
 
 is_wrapper() {
-    [ -f "$1" ] && grep -q 'termux-etc-seccomp' "$1" 2>/dev/null
+    # Match only the current single-tool form. Old wrappers that chain
+    # `sigsys_launcher termux-etc-seccomp` also contain the string
+    # `termux-etc-seccomp`, but must be replaced by the simpler form.
+    [ -f "$1" ] && grep -q 'exec termux-etc-seccomp' "$1" 2>/dev/null
 }
 
 wrap_go_cli() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 - refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to add the missing `workspaces` logging prefix (used by `dot_scripts/linux-engineering-workspace-aliases.sh`) to the documented prefix inventory
 
+### Fixed
+
+- fixed `is_wrapper()` idempotency check in `run_after_android-003-wrap-terra-clis.sh` to match only the current single-tool form (`exec termux-etc-seccomp`), replacing old wrappers that chain `sigsys_launcher termux-etc-seccomp` — the old chain is no longer needed because `termux-etc-seccomp` now handles SIGSYS suppression internally via a race-free TRACEME+blocking `waitpid` design
+
 ## [0.14.3] - 2026-06-09
 
 ### Changed
@@ -41,7 +45,6 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - hardened `install_sdkman` in `run_once_before_linux-002-install-dependencies.sh` to recreate `$SDKMAN_DIR/tmp` before `sdk install` (preventing `curl: Failed to open .../*.headers.tmp` when SDKMAN's tmp directory has been cleared) and to run `sdk selfupdate force` so candidate metadata stays current
 - updated `install_ggshield` in `run_once_before_linux-002-install-dependencies.sh` to run `python -m pipx upgrade ggshield` when ggshield is already present, so a new GitGuardian release no longer prints `A new version of ggshield (vX.Y.Z) has been released` on every commit hook invocation
 - updated `install_terra` in `run_once_before_android-002-install-dependencies.sh.tmpl` to pipe `yes y` into `terra update` so the y/N prompts for newer `terraform`/`terragrunt` blobs auto-answer on Android (terra itself is built from source, so `terra self-update` is intentionally not invoked)
-
 ## [0.14.0] - 2026-05-03
 
 ### Added


### PR DESCRIPTION
## Summary

- fixed the `is_wrapper()` idempotency check in `run_after_android-003-wrap-terra-clis.sh` to match only the current single-tool form (`exec termux-etc-seccomp`), so old wrappers that chain `sigsys_launcher termux-etc-seccomp` are replaced on the next `chezmoi apply`

## Background

Previously `termux-etc-seccomp` used `PTRACE_SEIZE` + `poll + SIGCHLD` to supervise the child process. This design had a race: Go's runtime spawns OS threads via `clone()` rapidly; a thread cloned between the `fork` and the parent draining the `PTRACE_EVENT_CLONE` stop hit `faccessat2` (syscall 439, blocked by Android's seccomp with `SECCOMP_RET_TRAP → SIGSYS`) before being traced. The unhandled SIGSYS killed the process (exit 159).

The workaround at the time was to chain `sigsys_launcher` (a separate SIGSYS-only ptrace supervisor using the race-free TRACEME+blocking `waitpid` design) as the outermost wrapper. The generated wrappers looked like:

```bash
exec sigsys_launcher termux-etc-seccomp "$RAW_BIN" "$@"
```

`termux-etc-seccomp` has now been redesigned (see [termux-etc-redirect PR #17](https://github.com/rios0rios0/termux-etc-redirect/pull/17)) to use the same TRACEME+blocking `waitpid` model internally. It handles both `/etc/` path redirection and SIGSYS suppression in a single tool, race-free. The chain is no longer needed.

## The bug in `is_wrapper()`

The old guard was:

```bash
is_wrapper() {
    [ -f "$1" ] && grep -q 'termux-etc-seccomp' "$1" 2>/dev/null
}
```

Old wrappers containing `sigsys_launcher termux-etc-seccomp` also matched this pattern, so `chezmoi apply` treated them as up-to-date and left the old chain in place. The new guard matches only the exact exec form:

```bash
is_wrapper() {
    [ -f "$1" ] && grep -q 'exec termux-etc-seccomp' "$1" 2>/dev/null
}
```

After `chezmoi apply` with this fix, wrappers that still reference `sigsys_launcher` are replaced with the correct single-tool form.

## Test plan

- [x] `chezmoi apply` (on a system where the old sigsys_launcher chain is installed) replaces both wrappers
- [x] `terragrunt --version` and `terraform --version` exit 0 under the new wrapper
- [x] `terragrunt find --working-dir <dir>` exits 0 (exercises both `faccessat2` SIGSYS suppression and `/etc/` openat redirect)
- [x] `chezmoi apply` a second time is a no-op (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)