### PR TITLE
feat: add ccswitch Claude account monitoring and rotation

### DIFF
--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -558,7 +558,7 @@ install_ccswitch() {
     local status
 
     installer="$(mktemp)"
-    if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/ccswitch/main/install.sh -o "$installer"; then
+    if ! curl --proto '=https' -fsSL https://raw.githubusercontent.com/rios0rios0/ccswitch/main/install.sh -o "$installer"; then
         echo "[configure-deps] ERROR: failed to download ccswitch installer" >&2
         rm -f "$installer"
         return 1

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -542,6 +542,35 @@ install_aisync() {
     return "$status"
 }
 
+# https://github.com/rios0rios0/ccswitch
+# `ccswitch` monitors Claude Code usage and rotates between backup Claude accounts
+# when the active account's limits are exhausted. Installed like `aisync`: fetch the
+# upstream `install.sh`, which downloads the pre-built `linux-<arch>` binary into
+# ~/.local/bin. The shell integration (claude wrapper + daemon start) lives in
+# `dot_zshrc.tmpl`.
+install_ccswitch() {
+    if command -v ccswitch &>/dev/null; then
+        echo "[configure-deps] ccswitch is already installed, skipping" >&2
+        return
+    fi
+
+    local installer
+    local status
+
+    installer="$(mktemp)"
+    if ! curl -fsSL https://raw.githubusercontent.com/rios0rios0/ccswitch/main/install.sh -o "$installer"; then
+        echo "[configure-deps] ERROR: failed to download ccswitch installer" >&2
+        rm -f "$installer"
+        return 1
+    fi
+
+    bash "$installer"
+    status=$?
+    rm -f "$installer"
+
+    return "$status"
+}
+
 # https://developer.atlassian.com/cloud/acli/guides/install-linux/
 # Atlassian only publishes a rolling `latest` endpoint (no versioned URLs, no checksums/signatures),
 # so pinning or cryptographic verification is not possible upstream; the install tracks the latest
@@ -604,6 +633,7 @@ install_pyenv
 
 install_cursor_cli
 install_claude_cli
+install_ccswitch
 install_gemini_cli
 install_dev_toolkit
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -184,6 +184,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
   - `linux-engineering-workspace-aliases.sh`: Creates shell aliases from `ws:` fields on 1Password device note
   - `linux-toolbox-watch-compress-folders.sh`: Background script watching and compressing `~/.histdb`, `~/.john`, etc.
   - `android-patch-claude-code-tmpdir.sh`: Patches Claude Code for Termux compatibility (replaces hardcoded `/tmp` paths, symlinks system ripgrep)
+- `dot_zshrc.tmpl` (Linux/WSL): starts the [`ccswitch`](https://github.com/rios0rios0/ccswitch) monitor daemon and wraps `claude` to rotate between backup Claude accounts when usage limits are exhausted; installed by `install_ccswitch()` in the Linux dependency script
 
 ### Platform Matrix
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,7 +163,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - `AppData/`: Windows-specific app config files deployed via `run_after_windows-003-copy-app-data-files.ps1.tmpl`
 
 ### Key Managed Files
-- `dot_zshrc.tmpl` → `~/.zshrc`: Zsh configuration with ZINIT plugins, version managers, aliases
+- `dot_zshrc.tmpl` → `~/.zshrc`: Zsh configuration with ZINIT plugins, version managers, aliases; on Linux/WSL also keeps the [`ccswitch`](https://github.com/rios0rios0/ccswitch) monitor daemon alive and wraps `claude` to rotate between backup Claude accounts when usage limits are exhausted
 - `dot_zshenv.tmpl` → `~/.zshenv`: PATH setup for all Zsh invocations (critical for IDE integration)
 - `dot_gitconfig.tmpl` → `~/.gitconfig`: Git config with 1Password SSH/GPG signing, per-device keys
 - `dot_p10k.zsh` → `~/.p10k.zsh`: Powerlevel10k theme configuration
@@ -184,7 +184,6 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
   - `linux-engineering-workspace-aliases.sh`: Creates shell aliases from `ws:` fields on 1Password device note
   - `linux-toolbox-watch-compress-folders.sh`: Background script watching and compressing `~/.histdb`, `~/.john`, etc.
   - `android-patch-claude-code-tmpdir.sh`: Patches Claude Code for Termux compatibility (replaces hardcoded `/tmp` paths, symlinks system ripgrep)
-- `dot_zshrc.tmpl` (Linux/WSL): starts the [`ccswitch`](https://github.com/rios0rios0/ccswitch) monitor daemon and wraps `claude` to rotate between backup Claude accounts when usage limits are exhausted; installed by `install_ccswitch()` in the Linux dependency script
 
 ### Platform Matrix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added [`ccswitch`](https://github.com/rios0rios0/ccswitch) integration: `install_ccswitch()` installs the CLI and `dot_zshrc.tmpl` starts its monitor daemon and wraps `claude` to rotate between backup Claude accounts when usage limits are exhausted (Linux/WSL, OAuth-based)
+
 ## [0.14.4] - 2026-06-18
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,14 @@ AI assistant rules (Claude Code, Cursor, Codex, Gemini, etc.) are **not** manage
 
 After the dependency installer finishes, run `aisync init`, `aisync source add guide --source-repo rios0rios0/guide --branch generated`, and `aisync pull` to populate the rules. Subsequent `aisync pull` calls refresh them on demand.
 
+## Claude Account Rotation (ccswitch)
+
+Claude Code subscription tokens live in `~/.claude/.credentials.json` (not chezmoi-managed on Linux/WSL). [`ccswitch`](https://github.com/rios0rios0/ccswitch) is a Go CLI installed by `install_ccswitch()` in the Linux/WSL dependency script that monitors Claude Code usage (via the `GET /api/oauth/usage` OAuth endpoint) and rotates between enrolled backup accounts when the active account's limits are exhausted.
+
+`dot_zshrc.tmpl` (Linux only) starts the `ccswitch monitor` daemon in interactive shells and wraps `claude` so each launch first runs `ccswitch ensure` — a no-network guard that installs the current account's credentials. Enroll each account once with `ccswitch enroll` after logging in via `claude` + `/login`; afterwards rotation is automatic, with no repeated `/login`. The `[ccswitch]` log prefix is emitted by the tool itself.
+
+**Note:** if `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` is set, Claude Code ignores the rotated OAuth credentials; `ccswitch` warns when it detects this.
+
 ## Encryption Setup
 
 - Private key: `~/.ssh/chezmoi`

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -405,4 +405,26 @@ source "$HOME/.scripts/linux-engineering-shell-credentials.sh"
 
 ###### Workspace Aliases ###########################################################
 source "$HOME/.scripts/linux-engineering-workspace-aliases.sh"
+{{- if eq .chezmoi.os "linux" }}
+
+###### Claude Account Rotation (ccswitch) ##########################################
+# Monitor Claude Code usage and rotate between backup accounts when limits run out.
+# See https://github.com/rios0rios0/ccswitch. Enroll accounts once with `ccswitch
+# enroll`; after that, rotation is automatic and no repeated `/login` is needed.
+if command -v ccswitch >/dev/null 2>&1; then
+    # Keep the usage-monitoring daemon alive; it starts detached only if not running.
+    if [[ -o interactive ]]; then
+        ccswitch monitor --ensure-daemon 2>/dev/null
+    fi
+
+    # Wrap `claude` so every launch first ensures the current (healthy) account's
+    # credentials are on disk. `command` bypasses this function to run the real CLI.
+    # This is interactive-only: non-interactive shells (IDEs, MCP servers) source
+    # `.zshenv`, not `.zshrc`, so they never pick up this wrapper.
+    claude() {
+        ccswitch ensure --quiet 2>/dev/null
+        command claude "$@"
+    }
+fi
+{{- end }}
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -409,8 +409,8 @@ source "$HOME/.scripts/linux-engineering-workspace-aliases.sh"
 
 ###### Claude Account Rotation (ccswitch) ##########################################
 # Monitor Claude Code usage and rotate between backup accounts when limits run out.
-# See https://github.com/rios0rios0/ccswitch. Enroll accounts once with `ccswitch
-# enroll`; after that, rotation is automatic and no repeated `/login` is needed.
+# See https://github.com/rios0rios0/ccswitch. Enroll each account once with
+# `ccswitch enroll`; afterwards rotation is automatic — no repeated `/login`.
 if command -v ccswitch >/dev/null 2>&1; then
     # Keep the usage-monitoring daemon alive; it starts detached only if not running.
     if [[ -o interactive ]]; then


### PR DESCRIPTION
## Summary

Integrates [`ccswitch`](https://github.com/rios0rios0/ccswitch) — a small Go CLI that monitors Claude Code usage and rotates between backup Claude accounts when the active account's limits are exhausted — into the dotfiles.

## Changes

- **`install_ccswitch()`** added to the Linux/WSL dependency installer, next to `install_claude_cli`, following the same upstream-`install.sh` pattern as `aisync`.
- **`dot_zshrc.tmpl`** (Linux only): in interactive shells it keeps the `ccswitch monitor` daemon alive and wraps `claude` so every launch first runs `ccswitch ensure` — a no-network guard that installs the current account's credentials. Interactive-only: non-interactive shells source `.zshenv`, not `.zshrc`, so IDE/MCP invocations are unaffected.
- Documented the integration in `CLAUDE.md`, `CHANGELOG.md`, and `.github/copilot-instructions.md`.

## Usage

After the installer runs, enroll each account once with `ccswitch enroll` (after logging in via `claude` + `/login`); rotation is then automatic — no repeated `/login`.

## Validation

- `make lint-templates` — 29/29 templates parse
- `make lint-shellcheck` — passes
- `make test-template-render` — passes; the ccswitch block renders correctly for Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
