### PR TITLE
feat(copilot): added GitHub Copilot CLI and removed Gemini CLI and Cursor

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -71,5 +71,4 @@ pyvenv.cfg
 {{- /* Additional Android exclusions: For example, ignore .gitconfig on Android even if it’s normally managed elsewhere. */ -}}
 {{- if eq .chezmoi.os "android" }}
 .age_recipients
-.cursor
 {{- end }}

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -343,6 +343,22 @@ install_copilot_cli() {
         return 0
     fi
 
+    # `install_nvm` returns early when npm already exists, so this may run under the
+    # Termux-provided Node. Check the major version explicitly rather than letting a
+    # doomed install download and fail (or install a package that breaks at runtime).
+    local nodeMajor
+    nodeMajor="$(node --version 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/')"
+    case "$nodeMajor" in
+        '' | *[!0-9]*)
+            echo "[copilot] WARN: could not determine the Node.js version, skipping" >&2
+            return 0
+            ;;
+    esac
+    if [ "$nodeMajor" -lt 22 ]; then
+        echo "[copilot] WARN: Node.js 22+ is required, found v$nodeMajor, skipping" >&2
+        return 0
+    fi
+
     npm install -g @github/copilot || {
         echo "[copilot] WARN: install failed, skipping" >&2
     }

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -331,9 +331,21 @@ install_pyenv() {
     fi
 }
 
-# https://github.com/google-gemini/gemini-cli
-install_gemini_cli() {
-    npm install -g @google/gemini-cli
+# https://github.com/github/copilot-cli
+# The agentic GitHub Copilot CLI (binary `copilot`), installed via npm so it must run
+# after `install_nvm`. Best-effort: the package ships platform-specific native
+# executables and Termux is bionic (not glibc/musl), so this may end up needing the
+# same wrapper treatment as Claude Code (see android-001e). A failure here must not
+# abort the remaining dependency installs.
+install_copilot_cli() {
+    if command_exists copilot; then
+        echo "[copilot] already installed, skipping" >&2
+        return 0
+    fi
+
+    npm install -g @github/copilot || {
+        echo "[copilot] WARN: install failed, skipping" >&2
+    }
 }
 
 # https://github.com/rios0rios0/dev-toolkit
@@ -373,26 +385,6 @@ install_github_cli() {
         rm -rf gh.tar.gz "gh_${GH_VERSION}_${ARCH}"
     else
         echo "GitHub CLI is already installed."
-    fi
-}
-
-# https://github.com/github/gh-copilot
-install_github_copilot() {
-    extensionsDir="$HOME/.local/share/gh/extensions"
-
-    if [ -d "$extensionsDir/gh-copilot" ]; then
-        echo "GitHub Copilot CLI is already installed."
-        return
-    fi
-
-    echo "[gh-copilot] installing GitHub Copilot extension (best-effort)..." >&2
-    # gh extension install requires authentication; skip gracefully if not authed
-    if ~/.local/bin/gh auth status &>/dev/null; then
-        ~/.local/bin/gh extension install github/gh-copilot || {
-            echo "[gh-copilot] WARN: extension install failed, skipping" >&2
-        }
-    else
-        echo "[gh-copilot] WARN: gh not authenticated, skipping copilot extension install" >&2
     fi
 }
 
@@ -553,7 +545,8 @@ install_azure_cli() {
 }
 
 # https://github.com/rios0rios0/aisync
-# `aisync` syncs AI assistant rules/agents/skills across `~/.claude/`, `~/.cursor/`, etc.
+# `aisync` syncs AI assistant rules/agents/skills across AI assistant home
+# directories such as `~/.claude/`.
 # It replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl
 # `install-rules.sh` from `rios0rios0/guide` on every chezmoi apply.
 # Uses Termux's native `golang` apt package (GVM is intentionally skipped on Android).
@@ -573,7 +566,7 @@ install_sdkman
 
 # TODO: same of the line 261
 install_nvm
-install_gemini_cli
+install_copilot_cli
 # Claude Code's musl distribution is bootstrapped manually following
 # examples/claude-code.md in rios0rios0/termux-etc-redirect (musl loader
 # seed + initial patchelf). Subsequent updates are handled by the wrapper
@@ -586,7 +579,6 @@ install_pyenv
 
 install_1password_cli
 install_github_cli
-install_github_copilot
 install_golangci_lint
 install_aws_cli
 install_azure_cli

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -292,15 +292,6 @@ install_pyenv() {
     eval "$(pyenv init -)"
 }
 
-# https://cursor.com/docs/cli/installation
-install_cursor_cli() {
-    if command -v agent &>/dev/null; then
-        echo "[configure-deps] Cursor CLI is already installed, skipping" >&2
-        return
-    fi
-    curl https://cursor.com/install -fsSL | bash
-}
-
 # https://github.com/anthropics/claude-code
 install_claude_cli() {
     if command -v claude &>/dev/null; then
@@ -310,13 +301,16 @@ install_claude_cli() {
     npm install -g @anthropic-ai/claude-code
 }
 
-# https://github.com/google-gemini/gemini-cli
-install_gemini_cli() {
-    if command -v gemini &>/dev/null; then
-        echo "[configure-deps] Gemini CLI is already installed, skipping" >&2
+# https://github.com/github/copilot-cli
+# The agentic GitHub Copilot CLI (binary `copilot`). Requires Node.js 22+, so it
+# must run after `install_nvm`. This supersedes the deprecated `github/gh-copilot`
+# `gh` extension, which only provided `gh copilot suggest`/`explain`.
+install_copilot_cli() {
+    if command -v copilot &>/dev/null; then
+        echo "[configure-deps] GitHub Copilot CLI is already installed, skipping" >&2
         return
     fi
-    npm install -g @google/gemini-cli
+    npm install -g @github/copilot
 }
 
 # https://github.com/rios0rios0/dev-toolkit
@@ -510,7 +504,8 @@ install_ruff() {
 }
 
 # https://github.com/rios0rios0/aisync
-# `aisync` syncs AI assistant rules/agents/skills across `~/.claude/`, `~/.cursor/`, etc.
+# `aisync` syncs AI assistant rules/agents/skills across AI assistant home
+# directories such as `~/.claude/`.
 # It replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl
 # `install-rules.sh` from `rios0rios0/guide` on every chezmoi apply.
 #
@@ -631,10 +626,9 @@ install_sdkman
 install_nvm
 install_pyenv
 
-install_cursor_cli
 install_claude_cli
 install_ccswitch
-install_gemini_cli
+install_copilot_cli
 install_dev_toolkit
 
 install_github_cli

--- a/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
+++ b/.chezmoiscripts/run_once_before_linux-002-install-dependencies.sh
@@ -302,15 +302,36 @@ install_claude_cli() {
 }
 
 # https://github.com/github/copilot-cli
-# The agentic GitHub Copilot CLI (binary `copilot`). Requires Node.js 22+, so it
-# must run after `install_nvm`. This supersedes the deprecated `github/gh-copilot`
-# `gh` extension, which only provided `gh copilot suggest`/`explain`.
+# The agentic GitHub Copilot CLI (binary `copilot`). This supersedes the deprecated
+# `github/gh-copilot` `gh` extension, which only provided `gh copilot suggest`/`explain`.
+#
+# Installed from the upstream install script (same shape as `install_ccswitch` and
+# `install_aisync`) rather than `npm install -g @github/copilot`. The npm package
+# relies on a postinstall lifecycle script to fetch its platform-specific binary, so
+# it breaks under `ignore-scripts=true` and cannot be installed with
+# `--ignore-scripts`. The upstream installer verifies checksums and honours PREFIX,
+# defaulting to `$HOME/.local/bin` for non-root — already on PATH via `dot_zshenv`.
 install_copilot_cli() {
     if command -v copilot &>/dev/null; then
         echo "[configure-deps] GitHub Copilot CLI is already installed, skipping" >&2
         return
     fi
-    npm install -g @github/copilot
+
+    local installer
+    local status
+
+    installer="$(mktemp)"
+    if ! curl --proto '=https' -fsSL https://gh.io/copilot-install -o "$installer"; then
+        echo "[configure-deps] ERROR: failed to download GitHub Copilot CLI installer" >&2
+        rm -f "$installer"
+        return 1
+    fi
+
+    PREFIX="$HOME/.local" bash "$installer"
+    status=$?
+    rm -f "$installer"
+
+    return "$status"
 }
 
 # https://github.com/rios0rios0/dev-toolkit

--- a/.chezmoiscripts/run_once_before_windows-001-install-dependencies.ps1
+++ b/.chezmoiscripts/run_once_before_windows-001-install-dependencies.ps1
@@ -97,12 +97,12 @@ Install-PackageList $communication
 # =========================================================================================================
 # Development
 $development = @(
-    "Anysphere.Cursor",
     "Anthropic.ClaudeCode",
     "CoreyButler.NVMforWindows",
     "Docker.DockerDesktop",
     "ExpressVPN.ExpressVPN",
     "GitHub.cli",
+    "GitHub.Copilot",                   # agentic GitHub Copilot CLI (binary `copilot`)
     "GoLang.Go",
     "JetBrains.Toolbox",
     "Microsoft.AzureStorageExplorer",
@@ -129,13 +129,3 @@ $gaming = @(
 )
 Install-PackageList $gaming
 # =========================================================================================================
-# Refresh the PATH environment variable
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-# =========================================================================================================
-# npm-based CLIs (requires NVM for Windows to be installed and a Node.js version active)
-# https://github.com/google-gemini/gemini-cli
-if (-not (Get-Command gemini -ErrorAction SilentlyContinue)) {
-    npm install -g @google/gemini-cli
-} else {
-    Write-Host "[install-deps] Gemini CLI is already installed, skipping"
-}

--- a/.docs/mcp-1password-setup.md
+++ b/.docs/mcp-1password-setup.md
@@ -11,7 +11,6 @@ The following items need to be created in the "Private" vault in 1Password:
 - **Anthropic API Key** - credential field containing Anthropic/Claude API key
 - **Browserbase API Key** - credential field containing Browserbase API key
 - **Browserbase Project ID** - credential field containing Browserbase project ID
-- **Gemini API Key** - credential field containing Google Gemini API key
 - **Smithery API Key** - credential field containing Smithery API key
 - **Smithery Profile** - credential field containing Smithery profile name
 - **EXA Search API Key** - credential field containing EXA Search API key

--- a/.github/ci/scripts/test-chezmoiignore.sh
+++ b/.github/ci/scripts/test-chezmoiignore.sh
@@ -71,7 +71,6 @@ check_platform "windows" \
 check_platform "android" \
     --ignore "windows-*.ps1" \
     --ignore "linux-*.sh" \
-    --ignore ".cursor" \
     --include ".termux" \
     --include ".config/mcphub"
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
   - **NVM** (v0.40.2) — Node.js version manager (installs LTS + corepack)
   - **Pyenv** — Python version manager (installs Python 3.13.2)
   - **Claude CLI** (`@anthropic-ai/claude-code` npm package)
-  - **GitHub Copilot CLI** (`@github/copilot` npm package, binary `copilot`; requires Node.js 22+)
+  - **GitHub Copilot CLI** (binary `copilot`, via upstream install script into `~/.local/bin`)
   - **GitHub CLI** (gh, via apt repository)
   - **Azure CLI** (via pip, installed into pyenv Python)
   - **ggshield** (GitGuardian CLI, via pipx) — installs a global pre-commit hook script at `~/.local/share/ggshield/git-hooks/pre-commit`; `core.hooksPath` in `~/.gitconfig` points all repos there

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -191,7 +191,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 | Prompt theme     | Powerlevel10k (`~/.p10k.zsh`)           | Oh My Posh (`~/.oh-my-posh.json`)   | Powerlevel10k (`~/.p10k.zsh`)           |
 | Script extension | `.sh`                                   | `.ps1`                              | `.sh`                                   |
 | Editor           | (any)                                   | JetBrains Toolbox / Visual Studio   | NeoVim (AstroVim, `~/.config/nvim/`)    |
-| MCP config       | `~/.claude.json` (Docker-based)         | N/A                                 | `~/.config/mcphub/servers.json` (npx)   |
+| MCP config       | `~/.claude.json` (Docker-based)         | `~/.claude.json` (Docker-based)     | `~/.config/mcphub/servers.json` (npx)   |
 | Terraform        | `terra` (same as Android)               | N/A                                 | `termux-etc-seccomp` wrapper (`terra`)  |
 | 1Password CLI    | `~/.local/bin/op` wrapper → `op.exe`    | Native `op.exe`                     | `~/.local/bin/op` → `termux-etc-seccomp` binary |
 | Docker           | Native                                  | Docker Desktop                      | N/A                                     |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,14 +73,13 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
   - **SDKMAN** — Java/Gradle ecosystem (installs latest Java and Gradle)
   - **NVM** (v0.40.2) — Node.js version manager (installs LTS + corepack)
   - **Pyenv** — Python version manager (installs Python 3.13.2)
-  - **Cursor CLI** — AI code editor CLI
   - **Claude CLI** (`@anthropic-ai/claude-code` npm package)
-  - **Gemini CLI** (`@google/gemini-cli` npm package)
+  - **GitHub Copilot CLI** (`@github/copilot` npm package, binary `copilot`; requires Node.js 22+)
   - **GitHub CLI** (gh, via apt repository)
   - **Azure CLI** (via pip, installed into pyenv Python)
   - **ggshield** (GitGuardian CLI, via pipx) — installs a global pre-commit hook script at `~/.local/share/ggshield/git-hooks/pre-commit`; `core.hooksPath` in `~/.gitconfig` points all repos there
   - **ruff** (Python linter, via Astral install script) — used by `make lint-python` to lint embedded Python in `modify_*` templates
-  - **aisync** ([`rios0rios0/aisync`](https://github.com/rios0rios0/aisync), via upstream install script) — syncs AI assistant rules/agents/skills into `~/.claude/`, `~/.cursor/`, etc.; replaces the legacy `run_after_*-install-ai-rules.*` scripts
+  - **aisync** ([`rios0rios0/aisync`](https://github.com/rios0rios0/aisync), via upstream install script) — syncs AI assistant rules/agents/skills into `~/.claude/` and other AI assistant home directories; replaces the legacy `run_after_*-install-ai-rules.*` scripts
   - **Speedtest CLI** (Ookla, via packagecloud)
 - Each tool installation can take 5-15 minutes individually
 - **Critical**: Script requires internet access for downloading tools
@@ -98,7 +97,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - Installs Termux packages: git, curl, age, eza, sqlite, vim, neovim, zsh, proot, proot-distro, etc.
 - Sets up `termux-etc-seccomp` wrapper for running pre-compiled Go binaries natively
 - Installs: Oh My Zsh, GVM, terra (custom wrapper for terraform/terragrunt), kubectl (ARM64), SDKMAN, NVM, pyenv
-- Installs: Claude CLI, Gemini CLI, 1Password CLI (ARM64 binary), GitHub CLI, Azure CLI (via pip), ruff (via apt), aisync (source build)
+- Installs: Claude CLI, GitHub Copilot CLI (npm, best-effort), 1Password CLI (ARM64 binary), GitHub CLI, Azure CLI (via pip), ruff (via apt), aisync (source build)
 - Configures NeoVim with AstroVim template (`~/.config/nvim`)
 - Configures Termux DNS (8.8.8.8, 8.8.4.4, 1.1.1.1)
 
@@ -108,9 +107,8 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - Installs: 1Password + CLI, age, Git, Oh My Posh, PowerShell 7, WSL, Windows Terminal
 - Installs hardware tools: CPU-Z ROG, AIDA64 Extreme, Logitech G HUB, Brother drivers, PerformanceTest
 - Installs utilities: Adobe Reader, GIMP, Notepad++, Spotify, VirtualBox, Grammarly, etc.
-- Installs development: Cursor, Claude Code, NVM for Windows, Docker Desktop, GitHub CLI, JetBrains Toolbox, Postman, ripgrep, jq, yq, bat, etc.
+- Installs development: Claude Code, GitHub Copilot CLI (`GitHub.Copilot`), NVM for Windows, Docker Desktop, GitHub CLI, JetBrains Toolbox, Postman, ripgrep, jq, yq, bat, etc.
 - Installs gaming: Steam, Epic Games, EA Desktop, GOG Galaxy
-- Installs npm CLI tools: `@google/gemini-cli`
 
 #### Windows Configuration (`.chezmoiscripts/run_once_before_windows-002-configure-dependencies.ps1`)
 - Installs/updates Kali Linux WSL distro and sets it as default
@@ -169,7 +167,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - `dot_p10k.zsh` → `~/.p10k.zsh`: Powerlevel10k theme configuration
 - `dot_oh-my-posh.json` → `~/.oh-my-posh.json`: Oh My Posh theme (Windows only)
 - `dot_age_recipients.tmpl` → `~/.age_recipients`: Age encryption recipients
-- `dot_cursor/mcp.json` → `~/.cursor/mcp.json`: MCP servers for Cursor (Linux, Docker-based)
+- `modify_dot_claude.json.tmpl` → `~/.claude.json`: MCP servers for Claude Code (Linux/Windows, Docker-based)
 - `dot_config/mcphub/servers.json.tmpl` → `~/.config/mcphub/servers.json`: MCP servers for mcphub (Android, npx-based)
 - `dot_config/nvim/` → `~/.config/nvim/`: NeoVim config (Android only, AstroVim-based)
 - `dot_scripts/` → `~/.scripts/`: User utility scripts
@@ -192,8 +190,8 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 | Shell            | Zsh + Oh My Zsh + Powerlevel10k         | PowerShell + Oh My Posh             | Zsh + Oh My Zsh + Powerlevel10k         |
 | Prompt theme     | Powerlevel10k (`~/.p10k.zsh`)           | Oh My Posh (`~/.oh-my-posh.json`)   | Powerlevel10k (`~/.p10k.zsh`)           |
 | Script extension | `.sh`                                   | `.ps1`                              | `.sh`                                   |
-| Editor           | (any)                                   | Cursor / Visual Studio              | NeoVim (AstroVim, `~/.config/nvim/`)    |
-| MCP config       | `~/.cursor/mcp.json` (Docker-based)     | N/A                                 | `~/.config/mcphub/servers.json` (npx)   |
+| Editor           | (any)                                   | JetBrains Toolbox / Visual Studio   | NeoVim (AstroVim, `~/.config/nvim/`)    |
+| MCP config       | `~/.claude.json` (Docker-based)         | N/A                                 | `~/.config/mcphub/servers.json` (npx)   |
 | Terraform        | `terra` (same as Android)               | N/A                                 | `termux-etc-seccomp` wrapper (`terra`)  |
 | 1Password CLI    | `~/.local/bin/op` wrapper → `op.exe`    | Native `op.exe`                     | `~/.local/bin/op` → `termux-etc-seccomp` binary |
 | Docker           | Native                                  | Docker Desktop                      | N/A                                     |
@@ -411,7 +409,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`
 
 ## Security and Encryption
 - Private key location: `~/.ssh/chezmoi` (Linux/Windows) or via `op` wrapper (Android)
@@ -435,7 +433,7 @@ Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-key
    - `~/.zshrc` (Linux/Android) or PowerShell profile (Windows) with custom settings
    - `~/.zshenv` (Linux/Android) for IDE-compatible PATH setup
    - `~/.gitconfig` with per-device SSH signing via 1Password
-   - `~/.cursor/mcp.json` (Linux) or `~/.config/mcphub/servers.json` (Android) with MCP servers
+   - `~/.claude.json` (Linux/Windows) or `~/.config/mcphub/servers.json` (Android) with MCP servers
 
 3. **Development Environment**:
    - kubectl, terraform, terragrunt available in PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added [`ccswitch`](https://github.com/rios0rios0/ccswitch) integration: `install_ccswitch()` installs the CLI and `dot_zshrc.tmpl` starts its monitor daemon and wraps `claude` to rotate between backup Claude accounts when usage limits are exhausted (Linux/WSL, OAuth-based)
+- added the agentic [GitHub Copilot CLI](https://github.com/github/copilot-cli) on all three platforms: `install_copilot_cli()` installs the `@github/copilot` npm package on Linux/WSL and Android (both after `install_nvm`, since it requires Node.js `22+`), and Windows installs the `GitHub.Copilot` winget package
+
+### Removed
+
+- removed Gemini CLI (`@google/gemini-cli`) from the Linux/WSL, Windows, and Android dependency installers, together with the Windows npm section that existed only to install it and the orphaned **Gemini API Key** entry in `.docs/mcp-1password-setup.md`
+- removed Cursor: deleted `dot_cursor/` (the `~/.cursor/mcp.json` modify script), `install_cursor_cli()` on Linux/WSL, the `Anysphere.Cursor` winget package on Windows, and the `.cursor` entries in `.chezmoiignore`, `dot_gitignore`, and `test-chezmoiignore.sh`
+- removed the deprecated `github/gh-copilot` `gh` extension install (`install_github_copilot()`) from the Android dependency script, which GitHub deprecated in favor of the agentic GitHub Copilot CLI
 
 ## [0.14.4] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Added
 
 - added [`ccswitch`](https://github.com/rios0rios0/ccswitch) integration: `install_ccswitch()` installs the CLI and `dot_zshrc.tmpl` starts its monitor daemon and wraps `claude` to rotate between backup Claude accounts when usage limits are exhausted (Linux/WSL, OAuth-based)
-- added the agentic [GitHub Copilot CLI](https://github.com/github/copilot-cli) on all three platforms: `install_copilot_cli()` installs the `@github/copilot` npm package on Linux/WSL and Android (both after `install_nvm`, since it requires Node.js `22+`), and Windows installs the `GitHub.Copilot` winget package
+- added the agentic [GitHub Copilot CLI](https://github.com/github/copilot-cli) on all three platforms: `install_copilot_cli()` installs it from the upstream install script into `~/.local/bin` on Linux/WSL and from the `@github/copilot` npm package on Android (best-effort, after `install_nvm`), and Windows installs the `GitHub.Copilot` winget package
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Platform-specific scripts in `.chezmoiscripts/` are prefixed: `linux-*`, `window
 | Shell      | Zsh + Oh My Zsh + p10k       | PowerShell + Oh My Posh | Zsh + Oh My Zsh + p10k           |
 | Scripts    | `.sh`                        | `.ps1`                  | `.sh`                            |
 | Docker     | Native                       | N/A                     | `termux-etc-seccomp` wrapper     |
-| MCP config | `modify_dot_claude.json.tmpl` (Docker-based) | N/A | `dot_config/mcphub/` (npx-based) |
+| MCP config | `modify_dot_claude.json.tmpl` (Docker-based) | `modify_dot_claude.json.tmpl` (Docker-based) | `dot_config/mcphub/` (npx-based) |
 | 1Password  | Native `op` CLI              | Native `op` CLI         | `termux-etc-seccomp` wrapper at `.local/bin/op` |
 
 ## Key Files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Platform-specific scripts in `.chezmoiscripts/` are prefixed: `linux-*`, `window
 | Shell      | Zsh + Oh My Zsh + p10k       | PowerShell + Oh My Posh | Zsh + Oh My Zsh + p10k           |
 | Scripts    | `.sh`                        | `.ps1`                  | `.sh`                            |
 | Docker     | Native                       | N/A                     | `termux-etc-seccomp` wrapper     |
-| MCP config | `dot_cursor/` (Docker-based) | N/A                     | `dot_config/mcphub/` (npx-based) |
+| MCP config | `modify_dot_claude.json.tmpl` (Docker-based) | N/A | `dot_config/mcphub/` (npx-based) |
 | 1Password  | Native `op` CLI              | Native `op` CLI         | `termux-etc-seccomp` wrapper at `.local/bin/op` |
 
 ## Key Files
@@ -152,7 +152,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `gh-copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`
 
 ## Important Timing Constraints
 
@@ -165,7 +165,7 @@ On Android, tool wrappers (`op`, `gh`) **must be `run_once_before` scripts**, NO
 The wrapper scripts follow a strict execution order:
 1. `android-001-create-wrapper.sh` — generic `termux-etc-seccomp` wrapper (all tool wrappers depend on this)
 2. `android-001a-create-op-wrapper.sh` — `op` wrapper (needed by chezmoi templates)
-3. `android-001b-create-gh-wrapper.sh` — `gh` wrapper (needed by install script for copilot)
+3. `android-001b-create-gh-wrapper.sh` — `gh` wrapper (backs the `gh_linux_arm64` binary installed in step 7)
 4. `android-001c-create-golangci-lint-wrapper.sh` — `golangci-lint` wrapper (backs the `golangci-lint_linux_arm64` binary installed in step 7)
 5. `android-001d-create-acli-wrapper.sh` — `acli` wrapper (backs the `acli_linux_arm64` binary installed in step 7)
 6. `android-001e-create-claude-wrapper.sh` — `claude` wrapper for Claude Code's `linux-arm64-musl` build (handles the background `patchelf`-aware auto-updater; first-time bootstrap is still manual via `examples/claude-code.md` in `rios0rios0/termux-etc-redirect`)
@@ -189,7 +189,7 @@ Android 12+ includes a **Phantom Process Killer** that enforces a system-wide li
 
 ## AI Rules Sync
 
-AI assistant rules (Claude Code, Cursor, Codex, Gemini, etc.) are **not** managed by chezmoi. Directories like `~/.claude/`, `~/.cursor/`, `~/.codex/` are listed in `.chezmoiignore` and synced separately by [`aisync`](https://github.com/rios0rios0/aisync), a Go CLI installed by `install_aisync()` in the Linux/WSL and Android dependency scripts (replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl `install-rules.sh` from `rios0rios0/guide` on every apply).
+AI assistant rules (Claude Code, GitHub Copilot CLI, Codex, etc.) are **not** managed by chezmoi. Directories like `~/.claude/` and `~/.codex/` are excluded from chezmoi and synced separately by [`aisync`](https://github.com/rios0rios0/aisync), a Go CLI installed by `install_aisync()` in the Linux/WSL and Android dependency scripts (replaces the legacy `run_after_*-install-ai-rules.*` scripts that used to curl `install-rules.sh` from `rios0rios0/guide` on every apply).
 
 After the dependency installer finishes, run `aisync init`, `aisync source add guide --source-repo rios0rios0/guide --branch generated`, and `aisync pull` to populate the rules. Subsequent `aisync pull` calls refresh them on demand.
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/), [1Passw
 
 ### Development Tools
 
-- **Cursor** (AI editor with Docker-based MCP servers on Linux)
-- **Claude Code** + **Gemini CLI** (AI coding assistants)
+- **Claude Code** + **GitHub Copilot CLI** (AI coding assistants)
 - **Neovim** with AstroVim (Android)
 
 ### Security and Pentesting
@@ -64,8 +63,8 @@ Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/), [1Passw
 | Scripts | `.sh` (bash) | `.ps1` (PowerShell) | `.sh` (bash) |
 | 1Password | `op` wrapper (calls `op.exe` from WSL) | Native `op.exe` | `op` wrapper (proot Alpine) |
 | Docker | Native | Docker Desktop | N/A (proot wrappers) |
-| MCP Config | `~/.cursor/mcp.json` (Docker) | N/A | `~/.config/mcphub/servers.json` (npx) |
-| Editor | Any | Cursor | Neovim (AstroVim) |
+| MCP Config | `~/.claude.json` (Docker) | N/A | `~/.config/mcphub/servers.json` (npx) |
+| Editor | Any | JetBrains Toolbox, Visual Studio | Neovim (AstroVim) |
 
 ## Installation
 
@@ -109,11 +108,10 @@ chezmoi init --apply rios0rios0
 ## Repository Structure
 
 ```
-.chezmoiscripts/         # 21 platform-specific setup scripts (run_once_before_*, run_after_*)
+.chezmoiscripts/         # 30 platform-specific setup scripts (run_once_before_*, run_after_*)
 .chezmoitemplates/       # Shared template fragments (font installer, MCP server logic, username)
 dot_claude/              # Claude Code config (settings, permissions, trust) -> ~/.claude/
 dot_config/              # XDG config (mcphub MCP servers for Android) -> ~/.config/
-dot_cursor/              # Cursor MCP config (Docker-based, Linux only) -> ~/.cursor/
 dot_docker/              # Docker daemon config -> ~/.docker/
 dot_scripts/             # Utility scripts (version manager, credential loader, git sync, etc.)
 dot_ssh/                 # SSH config, keys, signing (1Password-backed) -> ~/.ssh/

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/), [1Passw
 | Scripts | `.sh` (bash) | `.ps1` (PowerShell) | `.sh` (bash) |
 | 1Password | `op` wrapper (calls `op.exe` from WSL) | Native `op.exe` | `op` wrapper (proot Alpine) |
 | Docker | Native | Docker Desktop | N/A (proot wrappers) |
-| MCP Config | `~/.claude.json` (Docker) | N/A | `~/.config/mcphub/servers.json` (npx) |
+| MCP Config | `~/.claude.json` (Docker) | `~/.claude.json` (Docker) | `~/.config/mcphub/servers.json` (npx) |
 | Editor | Any | JetBrains Toolbox, Visual Studio | Neovim (AstroVim) |
 
 ## Installation

--- a/dot_cursor/modify_mcp.json.tmpl
+++ b/dot_cursor/modify_mcp.json.tmpl
@@ -1,4 +1,0 @@
-#!{{ lookPath "bash" }}
-# Merges platform-specific mcpServers into ~/.cursor/mcp.json
-# Receives current file content on stdin, outputs desired content on stdout.
-{{ template "lib-modify-mcp-servers.sh" . }}

--- a/dot_gitignore
+++ b/dot_gitignore
@@ -29,7 +29,6 @@ fabric.properties
 # Visual Studio
 .vs
 
-.cursor
 .claude/
 !.claude/settings.json
 .wakatime-project

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -1,6 +1,6 @@
 # ~/.zshenv: sourced for ALL zsh invocations (interactive, non-interactive, login, non-login)
 # This file sets up PATH for tools that need to be available in all shell contexts,
-# including non-interactive shells spawned by IDEs like Cursor, VSCode, etc.
+# including non-interactive shells spawned by IDEs like VSCode, JetBrains, etc.
 
 # Avoid running this file multiple times in the SAME shell process
 # Using $$ (current PID) ensures new shell processes still get initialized


### PR DESCRIPTION
Aligns the managed AI tooling with current needs: drops Gemini CLI and Cursor, adds the agentic **GitHub Copilot CLI** across all three platforms.

## Added

`install_copilot_cli()` installs the agentic [GitHub Copilot CLI](https://github.com/github/copilot-cli), each platform using the idiom it already uses:

| Platform | Method | Placement |
|---|---|---|
| Linux/WSL | upstream install script → `~/.local/bin` | AI-CLI cluster |
| Windows | `GitHub.Copilot` winget package | `$development` array, next to `GitHub.cli` |
| Android | `npm install -g @github/copilot` | Gemini's former slot, after `install_nvm` |

On Linux this follows the existing `install_ccswitch` / `install_aisync` / `install_dev_toolkit` shape (curl installer → `mktemp` → `bash`). The installer verifies checksums and honours `PREFIX`, so the binary lands in `~/.local/bin`, already on PATH via `dot_zshenv`. No npm and no Node.js 22+ dependency on Linux.

## Removed

- **Gemini CLI** from all three installers. On Windows this also removes the `npm-based CLIs` section and its PATH refresh, which existed *solely* to install Gemini and would otherwise have become dead scaffolding. Also drops the orphaned **Gemini API Key** entry in `.docs/mcp-1password-setup.md` (no template read it).
- **Cursor**: `dot_cursor/` (the `~/.cursor/mcp.json` modify script), `install_cursor_cli()`, the `Anysphere.Cursor` winget package, and the `.cursor` entries in `.chezmoiignore`, `dot_gitignore`, and `test-chezmoiignore.sh`. The last two are a coupled pair — dropping the ignore rule without the CI assertion breaks `make test`.
- **The deprecated `github/gh-copilot` extension** on Android. Worth calling out: it was the *old* `gh copilot suggest`/`explain` extension, which GitHub [deprecated in favor of the agentic CLI](https://github.blog/changelog/2026-01-21-install-and-use-github-copilot-cli-directly-from-the-github-cli/). So this change is not purely additive — it replaces obsolete tooling that shared the Copilot name.

## Why Linux does not use npm

The first push installed Copilot CLI via `npm install -g @github/copilot`. SonarCloud correctly flagged `shell:S6505` — omitting `--ignore-scripts` allows lifecycle scripts to run during installation.

Adding `--ignore-scripts` is **not** a valid fix: the package relies on a postinstall lifecycle script to fetch its platform-specific binary, and GitHub documents `npm_config_ignore_scripts=false` as the required form when `ignore-scripts=true` is set. Suppressing the rule would have left the real risk in place, and forcing the flag would have installed a broken CLI. Switching to the upstream install script resolves the finding rather than masking it.

Android keeps npm — it was not flagged, and it stays best-effort (see below).

## Notes for review

**Android carries real risk.** Copilot CLI ships platform-specific native executables and Termux is bionic — the same class of problem that forced the manual musl + `patchelf` bootstrap for Claude Code. The Android install is therefore **best-effort**: guarded by `command_exists` and wrapped in `|| WARN` so a failure degrades to a warning rather than aborting a 45–120 minute dependency install. It may still need the same wrapper treatment as Claude Code (`android-001e`); that is documented inline.

**Docs repointed.** With `dot_cursor/` gone, the Linux MCP config is `~/.claude.json` (from the root `modify_dot_claude.json.tmpl`). Verified that `.chezmoiignore`'s `.claude` pattern does not also match `.claude.json`, so it is genuinely deployed on Linux. Windows' Editor row now reads JetBrains Toolbox / Visual Studio, both already installed via winget.

**Drive-by fix:** corrected the `README.md` repository-structure count from `21` to `30` scripts (actual count) since it sits in the same block as the `dot_cursor/` removal.

## Validation

- `make lint` — passes (28/28 templates, shellcheck, embedded Python, YAML/JSON)
- `make test` — passes
- `make sast` — no new findings; pre-existing only (a PEM sentinel in the `ssh-item-sample.json` test fixture from historical commit `a06b0bdc`, and unpinned `actions/checkout@v6` SHAs in untouched workflows)

> Two unrelated papercuts noticed while working, not addressed here:
> - `test-script-order` is locale-sensitive. Under `en_US.UTF-8` collation the hyphen is ignored, so `001a-` sorts before `001-` and the android check fails spuriously. It passes under `LC_ALL=C`, which is what CI and chezmoi use. Might be worth pinning `LC_ALL=C` inside that script.
> - `make sast` writes to `build/reports/`, which is not gitignored, so `git add -A` silently stages report artifacts. A repo-level `.gitignore` with `build/` would prevent that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)