### PR TITLE
feat(removal): added dependency tombstones so removals reach existing machines

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -1,0 +1,17 @@
+# Targets removed from the home directory on every `chezmoi apply`.
+#
+# chezmoi only looks at the current state of the source directory -- it has no
+# history, so deleting a `dot_*` file here does NOT delete the file it already
+# deployed to existing machines. Listing the target here does.
+#
+# Entries are permanent while they are listed: anything matching is deleted on
+# every apply, so only list paths that must never exist on a managed machine.
+# The package half of the same problem lives in the
+# `run_onchange_after_*-remove-dependencies.*` scripts.
+# See `.docs/dependency-lifecycle.md`.
+
+# Cursor -- removed in 601cbeb (2026-07-21), previously managed as dot_cursor/
+.cursor
+
+# Gemini CLI -- removed in 601cbeb (2026-07-21)
+.gemini

--- a/.chezmoiscripts/run_onchange_after_android-004-remove-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_android-004-remove-dependencies.sh.tmpl
@@ -1,0 +1,26 @@
+#!{{ lookPath "bash" }}
+
+# Removes dependencies that this repository used to install on Android (Termux)
+# but no longer declares in run_once_before_android-002-install-dependencies.sh.tmpl.
+#
+# This is a `run_onchange_` script: chezmoi re-runs it whenever the tombstone list
+# below changes, and every handler is idempotent, so it is a silent no-op once a
+# machine is clean. See `.docs/dependency-lifecycle.md` for why this exists.
+
+set -euo pipefail
+
+{{ template "lib-remove-dependencies.sh" }}
+
+# Format: "<strategy>:<target>" -- strategies are defined in the library above.
+# Add one group per removal, newest first, and reference the commit that dropped
+# the installer so the entry can be retired once every machine has converged.
+TOMBSTONES=(
+    # Gemini CLI -- removed in 601cbeb (2026-07-21)
+    "npm_global:@google/gemini-cli"
+
+    # `gh-copilot` extension, deprecated in favor of the agentic GitHub Copilot
+    # CLI -- removed in 601cbeb (2026-07-21)
+    "gh_extension:github/gh-copilot"
+)
+
+apply_tombstones "${TOMBSTONES[@]}"

--- a/.chezmoiscripts/run_onchange_after_linux-006-remove-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_linux-006-remove-dependencies.sh.tmpl
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Removes dependencies that this repository used to install on Linux (baremetal/WSL)
+# but no longer declares in run_once_before_linux-002-install-dependencies.sh.
+#
+# This is a `run_onchange_` script: chezmoi re-runs it whenever the tombstone list
+# below changes, and every handler is idempotent, so it is a silent no-op once a
+# machine is clean. See `.docs/dependency-lifecycle.md` for why this exists.
+
+set -euo pipefail
+
+{{ template "lib-remove-dependencies.sh" }}
+
+# Format: "<strategy>:<target>" -- strategies are defined in the library above.
+# Add one group per removal, newest first, and reference the commit that dropped
+# the installer so the entry can be retired once every machine has converged.
+TOMBSTONES=(
+    # Gemini CLI and Cursor CLI -- removed in 601cbeb (2026-07-21)
+    "npm_global:@google/gemini-cli"
+    "path:$HOME/.local/bin/cursor-agent"
+    "path:$HOME/.local/share/cursor-agent"
+)
+
+apply_tombstones "${TOMBSTONES[@]}"

--- a/.chezmoiscripts/run_onchange_after_windows-005-remove-dependencies.ps1
+++ b/.chezmoiscripts/run_onchange_after_windows-005-remove-dependencies.ps1
@@ -30,7 +30,12 @@ function Remove-WingetPackage {
 
     if ($PSCmdlet.ShouldProcess($Target, "Uninstall winget package")) {
         Write-Host "[$prefix] removing winget package: $Target"
-        winget uninstall --id $Target --exact --accept-source-agreements | Out-Null
+        # --silent and --disable-interactivity keep an unattended `chezmoi apply`
+        # from stalling on a prompt. Note that --accept-package-agreements is an
+        # install-only flag; winget rejects it here with "Argument name was not
+        # recognized for the current command".
+        winget uninstall --id $Target --exact `
+            --accept-source-agreements --silent --disable-interactivity | Out-Null
         $script:removed++
     }
 }

--- a/.chezmoiscripts/run_onchange_after_windows-005-remove-dependencies.ps1
+++ b/.chezmoiscripts/run_onchange_after_windows-005-remove-dependencies.ps1
@@ -1,0 +1,115 @@
+# Removes dependencies that this repository used to install on Windows but no
+# longer declares in run_once_before_windows-001-install-dependencies.ps1.
+#
+# Deleting a package from the installer only stops NEW machines from getting the
+# tool -- machines that already ran it keep the tool forever. chezmoi has no
+# concept of packages (it only knows about scripts), so uninstallation has to be
+# explicit. See `.docs/dependency-lifecycle.md`.
+#
+# This is a `run_onchange_` script: chezmoi re-runs it whenever the tombstone list
+# below changes, and every handler is idempotent, so it is a silent no-op once a
+# machine is clean.
+
+$prefix = "remove-deps"
+$script:removed = 0
+
+# =========================================================================================================
+# Removal strategies. Each handler takes the target as its only argument, returns
+# without acting when the target is already absent, and logs only when it actually
+# removes something.
+
+# Uninstall a winget package by its exact package ID.
+function Remove-WingetPackage {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Target)
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) { return }
+
+    $listed = winget list --id $Target --exact --accept-source-agreements 2>$null | Out-String
+    if ($listed -notmatch [regex]::Escape($Target)) { return }
+
+    if ($PSCmdlet.ShouldProcess($Target, "Uninstall winget package")) {
+        Write-Host "[$prefix] removing winget package: $Target"
+        winget uninstall --id $Target --exact --accept-source-agreements | Out-Null
+        $script:removed++
+    }
+}
+
+# Uninstall a globally installed npm package.
+function Remove-NpmGlobalPackage {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Target)
+
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) { return }
+
+    npm ls -g --depth=0 $Target 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { return }
+
+    if ($PSCmdlet.ShouldProcess($Target, "Uninstall npm global package")) {
+        Write-Host "[$prefix] removing npm global package: $Target"
+        npm uninstall -g $Target | Out-Null
+        $script:removed++
+    }
+}
+
+# Delete a file or directory left behind by an installer.
+function Remove-TargetPath {
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Target)
+
+    if (-not (Test-Path -LiteralPath $Target)) { return }
+
+    # Safety rail: this runs unattended on every tombstone change, so it must
+    # never delete outside the user profile directory.
+    $userHome = [System.IO.Path]::GetFullPath($HOME)
+    $resolved = [System.IO.Path]::GetFullPath($Target)
+    if (-not $resolved.StartsWith($userHome + [System.IO.Path]::DirectorySeparatorChar)) {
+        Write-Host "[$prefix] WARN: refusing to remove '$Target' (outside `$HOME)"
+        return
+    }
+
+    if ($PSCmdlet.ShouldProcess($Target, "Remove path")) {
+        Write-Host "[$prefix] removing path: $Target"
+        # -Confirm:$false so the outer ShouldProcess is the only decision point.
+        Remove-Item -LiteralPath $Target -Recurse -Force -Confirm:$false
+        $script:removed++
+    }
+}
+
+# Strategy name -> handler function.
+$removalHandlers = @{
+    "npm_global" = "Remove-NpmGlobalPackage"
+    "path"       = "Remove-TargetPath"
+    "winget"     = "Remove-WingetPackage"
+}
+
+# =========================================================================================================
+# Tombstone list, format "<strategy>:<target>". Add one group per removal, newest
+# first, and reference the commit that dropped the installer so the entry can be
+# retired once every machine has converged.
+$tombstones = @(
+    # Cursor and Gemini CLI -- removed in 601cbeb (2026-07-21)
+    "winget:Anysphere.Cursor",
+    "npm_global:@google/gemini-cli"
+)
+
+foreach ($tombstone in $tombstones) {
+    $strategy, $target = $tombstone -split ":", 2
+
+    if (-not $removalHandlers.ContainsKey($strategy)) {
+        Write-Host "[$prefix] WARN: unknown removal strategy '$strategy' for '$target', skipping"
+        continue
+    }
+
+    # A single failed removal must never abort `chezmoi apply`.
+    try {
+        & $removalHandlers[$strategy] $target
+    }
+    catch {
+        Write-Host "[$prefix] WARN: failed to remove '$target' via '$strategy': $_"
+    }
+}
+
+if ($script:removed -gt 0) {
+    Write-Host "[$prefix] removed $($script:removed) leftover dependency entries"
+}

--- a/.chezmoitemplates/lib-remove-dependencies.sh
+++ b/.chezmoitemplates/lib-remove-dependencies.sh
@@ -15,6 +15,12 @@ removed=0
 # =========================================================================================================
 # Removal strategies. Each handler takes the target as $1, returns 0 when the
 # target is already absent, and logs only when it actually removes something.
+#
+# Every mutating command is followed by `|| return 1` so a failed removal is
+# reported by `apply_tombstones` instead of being swallowed. `set -e` does NOT
+# help here: handlers are invoked from an `if !` condition, which disables
+# errexit for the whole call, so without the explicit guard a failing command
+# would fall through, still bump `removed`, and return success.
 
 # Uninstall a globally installed npm package.
 remove_npm_global() {
@@ -23,7 +29,7 @@ remove_npm_global() {
     npm ls -g --depth=0 "$package" &>/dev/null || return 0
 
     echo "[$prefix] removing npm global package: $package" >&2
-    npm uninstall -g "$package" >&2
+    npm uninstall -g "$package" >&2 || return 1
     removed=$((removed + 1))
 }
 
@@ -33,8 +39,10 @@ remove_path() {
     [[ -e "$target" || -L "$target" ]] || return 0
 
     # Safety rail: this runs unattended on every tombstone change, so it must
-    # never delete outside the home directory. The `?*` guard also rejects a
-    # bare "$HOME" and "$HOME/".
+    # never delete outside the home directory. Two independent checks are needed.
+    #
+    # 1. The target must sit under $HOME. The `?*` guard also rejects a bare
+    #    "$HOME" and "$HOME/".
     case "$target" in
         "$HOME"/?*) ;;
         *)
@@ -43,8 +51,19 @@ remove_path() {
             ;;
     esac
 
+    # 2. No `..` component, which would satisfy the prefix check above yet still
+    #    escape $HOME (e.g. "$HOME/../outside"). Wrapping the target in slashes
+    #    means a real component always shows up as "/../", so a legitimate name
+    #    like "foo..bar" is not caught.
+    case "/$target/" in
+        */../*)
+            echo "[$prefix] WARN: refusing to remove '$target' (contains a '..' component)" >&2
+            return 0
+            ;;
+    esac
+
     echo "[$prefix] removing path: $target" >&2
-    rm -rf -- "$target"
+    rm -rf -- "$target" || return 1
     removed=$((removed + 1))
 }
 
@@ -66,7 +85,7 @@ remove_gh_extension() {
     "$gh_bin" extension list 2>/dev/null | grep -qF "$extension" || return 0
 
     echo "[$prefix] removing gh extension: $extension" >&2
-    "$gh_bin" extension remove "$extension" >&2
+    "$gh_bin" extension remove "$extension" >&2 || return 1
     removed=$((removed + 1))
 }
 
@@ -77,7 +96,7 @@ remove_pipx() {
     pipx list --short 2>/dev/null | grep -qE "^${app} " || return 0
 
     echo "[$prefix] removing pipx application: $app" >&2
-    pipx uninstall "$app" >&2
+    pipx uninstall "$app" >&2 || return 1
     removed=$((removed + 1))
 }
 
@@ -107,7 +126,7 @@ remove_apt() {
     fi
 
     echo "[$prefix] removing apt package: $package" >&2
-    "${apt_cmd[@]}" remove -y "$package" >&2
+    "${apt_cmd[@]}" remove -y "$package" >&2 || return 1
     removed=$((removed + 1))
 }
 

--- a/.chezmoitemplates/lib-remove-dependencies.sh
+++ b/.chezmoitemplates/lib-remove-dependencies.sh
@@ -1,0 +1,147 @@
+# shellcheck shell=bash
+# Shared dependency-removal library included by platform-specific wrappers.
+#
+# Deleting an `install_*()` function from a dependency installer only stops NEW
+# machines from getting the tool -- machines that already ran it keep the tool
+# forever. chezmoi has no concept of packages (it only knows about scripts), so
+# uninstallation has to be explicit. See `.docs/dependency-lifecycle.md`.
+#
+# Callers declare a tombstone list and pass it to `apply_tombstones`. Every
+# handler is idempotent and quiet, so a clean machine produces no output.
+
+prefix="remove-deps"
+removed=0
+
+# =========================================================================================================
+# Removal strategies. Each handler takes the target as $1, returns 0 when the
+# target is already absent, and logs only when it actually removes something.
+
+# Uninstall a globally installed npm package.
+remove_npm_global() {
+    local package="$1"
+    command -v npm &>/dev/null || return 0
+    npm ls -g --depth=0 "$package" &>/dev/null || return 0
+
+    echo "[$prefix] removing npm global package: $package" >&2
+    npm uninstall -g "$package" >&2
+    removed=$((removed + 1))
+}
+
+# Delete a file, symlink, or directory left behind by an upstream installer.
+remove_path() {
+    local target="$1"
+    [[ -e "$target" || -L "$target" ]] || return 0
+
+    # Safety rail: this runs unattended on every tombstone change, so it must
+    # never delete outside the home directory. The `?*` guard also rejects a
+    # bare "$HOME" and "$HOME/".
+    case "$target" in
+        "$HOME"/?*) ;;
+        *)
+            echo "[$prefix] WARN: refusing to remove '$target' (outside \$HOME)" >&2
+            return 0
+            ;;
+    esac
+
+    echo "[$prefix] removing path: $target" >&2
+    rm -rf -- "$target"
+    removed=$((removed + 1))
+}
+
+# Remove a `gh` CLI extension.
+remove_gh_extension() {
+    local extension="$1"
+    local gh_bin=""
+
+    # Android installs `gh` into ~/.local/bin via a wrapper, which is not always
+    # on PATH during a non-interactive chezmoi run.
+    if command -v gh &>/dev/null; then
+        gh_bin="$(command -v gh)"
+    elif [[ -x "$HOME/.local/bin/gh" ]]; then
+        gh_bin="$HOME/.local/bin/gh"
+    else
+        return 0
+    fi
+
+    "$gh_bin" extension list 2>/dev/null | grep -qF "$extension" || return 0
+
+    echo "[$prefix] removing gh extension: $extension" >&2
+    "$gh_bin" extension remove "$extension" >&2
+    removed=$((removed + 1))
+}
+
+# Uninstall a pipx-managed application.
+remove_pipx() {
+    local app="$1"
+    command -v pipx &>/dev/null || return 0
+    pipx list --short 2>/dev/null | grep -qE "^${app} " || return 0
+
+    echo "[$prefix] removing pipx application: $app" >&2
+    pipx uninstall "$app" >&2
+    removed=$((removed + 1))
+}
+
+# Uninstall a dpkg/apt package.
+#
+# On Termux, apt runs unprivileged inside the app sandbox. On Linux/WSL it needs
+# root, and because chezmoi runs unattended the removal is skipped with an
+# actionable warning when passwordless sudo is unavailable -- blocking
+# `chezmoi apply` on a password prompt would be worse than leaving the package.
+remove_apt() {
+    local package="$1"
+    command -v dpkg-query &>/dev/null || return 0
+    dpkg-query -W -f='${Status}' "$package" 2>/dev/null |
+        grep -q '^install ok installed$' || return 0
+
+    local -a apt_cmd
+    if [[ "$(id -u)" -eq 0 ]]; then
+        apt_cmd=(apt-get)
+    elif [[ -n "${PREFIX:-}" && -d "${PREFIX:-}/var/lib/dpkg" ]]; then
+        apt_cmd=(apt-get)
+    elif sudo -n true 2>/dev/null; then
+        apt_cmd=(sudo -n apt-get)
+    else
+        echo "[$prefix] WARN: '$package' is still installed but passwordless sudo is unavailable" >&2
+        echo "[$prefix] WARN: remove it manually with: sudo apt-get remove -y $package" >&2
+        return 0
+    fi
+
+    echo "[$prefix] removing apt package: $package" >&2
+    "${apt_cmd[@]}" remove -y "$package" >&2
+    removed=$((removed + 1))
+}
+
+# Strategy name -> handler function.
+declare -A REMOVAL_HANDLERS=(
+    ["apt"]=remove_apt
+    ["gh_extension"]=remove_gh_extension
+    ["npm_global"]=remove_npm_global
+    ["path"]=remove_path
+    ["pipx"]=remove_pipx
+)
+
+# =========================================================================================================
+# Run every "<strategy>:<target>" tombstone passed as an argument.
+apply_tombstones() {
+    local tombstone strategy target handler
+
+    for tombstone in "$@"; do
+        strategy="${tombstone%%:*}"
+        target="${tombstone#*:}"
+
+        handler="${REMOVAL_HANDLERS[$strategy]:-}"
+        if [[ -z "$handler" ]]; then
+            echo "[$prefix] WARN: unknown removal strategy '$strategy' for '$target', skipping" >&2
+            continue
+        fi
+
+        # A single failed removal must never abort `chezmoi apply`.
+        if ! "$handler" "$target"; then
+            echo "[$prefix] WARN: failed to remove '$target' via '$strategy'" >&2
+        fi
+    done
+
+    if [[ "$removed" -gt 0 ]]; then
+        echo "[$prefix] removed $removed leftover dependency entries" >&2
+    fi
+}

--- a/.docs/dependency-lifecycle.md
+++ b/.docs/dependency-lifecycle.md
@@ -1,0 +1,163 @@
+# Dependency Lifecycle: Adding *and* Removing
+
+This repository is a **sync**, not a bootstrapper. Removing something from the source
+must remove it from every machine, not merely stop new machines from getting it.
+
+This document describes how removal works here, and records why the obvious
+off-the-shelf tools (Nix/home-manager, Homebrew Bundle, Ansible) were not selected.
+
+## The Problem
+
+chezmoi's declarative model covers the *contents* of files it manages. It does not
+cover the *existence* of things it once created, and it has no concept of packages
+at all. Two distinct gaps follow from that.
+
+Deleting `install_cursor_cli()` from the dependency installer in commit `601cbeb`
+stopped new machines from getting Cursor. It did nothing to the machines that had
+already run it — a month later `cursor-agent` and `gemini` were still installed and
+still on `PATH`. The same applies to files: deleting `dot_cursor/` from the source
+did not delete `~/.cursor/` from any machine that had already applied it.
+
+chezmoi is explicit that this is by design:
+
+> chezmoi only looks at the current state of the source directory, it doesn't know
+> anything about its history, and so can't tell if a file has been removed.
+> — [`.chezmoiremove` reference](https://www.chezmoi.io/reference/special-files/chezmoiremove/)
+
+> Uninstalling has to be explicit. chezmoi has no concept of brew or packages.
+> chezmoi only knows about scripts.
+> — chezmoi maintainer, [discussion #4650](https://github.com/twpayne/chezmoi/discussions/4650)
+
+## The Model
+
+| Half | Mechanism | Where |
+|------|-----------|-------|
+| **Files** — config left in `$HOME` | [`.chezmoiremove`](https://www.chezmoi.io/reference/special-files/chezmoiremove/) | `.chezmoiremove` at the repository root |
+| **Packages** — installed binaries | Tombstone scripts | `.chezmoiscripts/run_onchange_after_<platform>-*-remove-dependencies.*` |
+
+### File removal
+
+`.chezmoiremove` lists target paths that must never exist on a managed machine.
+Anything matching is deleted on **every** `chezmoi apply`. Patterns are relative to
+the home directory, `#` starts a comment, and the file is always interpreted as a
+Go template.
+
+### Package removal
+
+The tombstone scripts hold an explicit list of things this repository used to
+install. Each entry pairs a **removal strategy** with a **target**:
+
+```bash
+TOMBSTONES=(
+    # Gemini CLI and Cursor CLI -- removed in 601cbeb (2026-07-21)
+    "npm_global:@google/gemini-cli"
+    "path:$HOME/.local/bin/cursor-agent"
+    "path:$HOME/.local/share/cursor-agent"
+)
+```
+
+Strategies are implemented once in `.chezmoitemplates/lib-remove-dependencies.sh`
+(shared by Linux and Android) and inline in the Windows script. Every handler is
+idempotent, so a clean machine produces no output.
+
+| Strategy | Platforms | Removes |
+|----------|-----------|---------|
+| `apt` | Linux, Android | A dpkg/apt package |
+| `gh_extension` | Linux, Android | A `gh` CLI extension |
+| `npm_global` | all | A globally installed npm package |
+| `path` | all | A file, symlink, or directory (constrained to `$HOME`) |
+| `pipx` | Linux, Android | A pipx-managed application |
+| `winget` | Windows | A winget package by exact ID |
+
+The scripts are `run_onchange_`, so chezmoi re-runs them whenever the tombstone
+list changes and skips them otherwise.
+
+## Workflow: Removing a Dependency
+
+1. Delete the `install_*()` function (or package-list entry) from the platform's
+   `run_once_before_*-install-dependencies.*` script — as before.
+2. **Add a tombstone** to the matching `run_onchange_after_*-remove-dependencies.*`
+   script for every platform that installed it, with the strategy that undoes how
+   it was installed.
+3. **Add any leftover config directory** to `.chezmoiremove`.
+4. Reference the removing commit in a comment so the entry can be retired later.
+5. Update `CHANGELOG.md` under `[Unreleased] > Removed`.
+
+Steps 2 and 3 are the ones that make the repository a sync. Skipping them leaves
+the tool installed forever on every existing machine.
+
+## Alternatives Considered
+
+### Nix + home-manager — rejected: cannot cover the platform matrix
+
+[home-manager](https://github.com/nix-community/home-manager) is the genuinely
+declarative answer. It builds generations and `home-manager switch` removes
+whatever you deleted from the configuration, with no explicit uninstall list. It is
+strictly better than tombstones *where it runs*.
+
+It cannot run across this repository's three targets:
+
+| Target | home-manager | Consequence |
+|--------|--------------|-------------|
+| Kali on WSL | supported | would work |
+| Windows 11 native | **not supported** | winget, PowerShell, Oh My Posh, Windows Terminal, and the `AppData/` tree have no Nix story — Nix on Windows exists only inside WSL |
+| Termux on Android | only via [nix-on-droid](https://github.com/nix-community/nix-on-droid) | nix-on-droid is a **fork** of the Termux app with its own bootstrap, incompatible with the `termux-etc-seccomp` wrapper architecture (`op`, `gh`, `acli`, `claude`) that this repository depends on |
+
+Adopting Nix would mean either abandoning two of three platforms or maintaining two
+parallel dependency systems — strictly more complexity than a tombstone list, for a
+benefit that only lands on one platform. The cost is also front-loaded: every
+existing `install_*()` function would need a Nix expression before the first
+removal could be expressed declaratively.
+
+This is a platform-matrix constraint, not a judgement about Nix. If Windows and
+Android were ever dropped, home-manager would be the correct replacement for both
+the installer and the tombstone scripts.
+
+### Homebrew Bundle — rejected: only reconciles its own packages
+
+[`brew bundle cleanup --force`](https://docs.brew.sh/Brew-Bundle-and-Brewfile)
+uninstalls anything not listed in the `Brewfile`, which is true reconciliation and
+works on Linux. It only sees packages Homebrew installed.
+
+The Linux installer alone uses six mechanisms — `apt` (×8), `pip` (×4), upstream
+`curl | sh` installers (×4), `npm -g` (×3), `pipx` (×2), and `go install` — plus
+GVM, SDKMAN, NVM, Pyenv, krew, and Oh My Zsh, each with a bespoke installer.
+Homebrew would reconcile none of them without first migrating every dependency to
+Homebrew, which is not possible for the version managers and does not help Windows
+or Android at all.
+
+### Ansible — rejected: not actually reconciliation
+
+Ansible's `state: absent` still requires naming every package to remove, so it is
+the same explicit list as a tombstone script with a heavier runtime added. It would
+replace a shell array with a YAML array and pull in a Python control-node
+dependency on Termux and Windows.
+
+## Known Limitations
+
+These are accepted trade-offs, not oversights.
+
+- **The tombstone list is append-only and hand-maintained.** It is a record of
+  removals, not a diff against a declared set. Forgetting step 2 silently leaves
+  the dependency installed. This is the cost of not adopting Nix.
+- **`.chezmoiremove` entries are permanent while listed.** If Cursor were ever
+  reinstalled manually, `~/.cursor` would be deleted on the next apply until the
+  entry is removed from `.chezmoiremove`.
+- **`apt` removals need passwordless sudo on Linux/WSL.** chezmoi runs unattended,
+  so the handler warns and skips rather than blocking on a password prompt.
+  Termux needs no privilege escalation and is unaffected.
+- **Entries can be retired, but only deliberately.** Once every machine has
+  converged, a tombstone can be deleted. There is no signal for when that is true,
+  so the commit reference in each comment is the only dating mechanism.
+
+True reconciliation — recording what the repository installed and diffing it
+against a declared manifest — would remove the first limitation at the cost of
+building a small package manager. Revisit if the tombstone list becomes unwieldy.
+
+## References
+
+- [chezmoi: install packages declaratively](https://www.chezmoi.io/user-guide/advanced/install-packages-declaratively/)
+- [chezmoi: `.chezmoiremove`](https://www.chezmoi.io/reference/special-files/chezmoiremove/)
+- [chezmoi discussion #4650 — managing brew installations/uninstallations](https://github.com/twpayne/chezmoi/discussions/4650)
+- [home-manager](https://github.com/nix-community/home-manager) / [nix-on-droid](https://github.com/nix-community/nix-on-droid)
+- [Homebrew Bundle and Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile)

--- a/.github/ci/scripts/test-remove-dependencies.sh
+++ b/.github/ci/scripts/test-remove-dependencies.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+set -euo pipefail
+
+# Exercises .chezmoitemplates/lib-remove-dependencies.sh. This library calls
+# `rm -rf` unattended on every tombstone change, so the $HOME safety rail and the
+# no-op-when-clean behaviour are covered explicitly.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+LIB="$REPO_ROOT/.chezmoitemplates/lib-remove-dependencies.sh"
+EXIT_CODE=0
+CASE_INDEX=0
+
+echo "[test-remove-dependencies] testing dependency removal library..." >&2
+
+if [ ! -f "$LIB" ]; then
+    echo "[test-remove-dependencies] FAIL: library not found at $LIB" >&2
+    exit 1
+fi
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+# Runs a test case in its own bash process with HOME redirected into the sandbox,
+# so the $HOME-scoped safety rail is exercised without touching the real home.
+run_case() {
+    local description="$1"
+    local body="$2"
+
+    CASE_INDEX=$((CASE_INDEX + 1))
+    local case_home="$SANDBOX/home-$CASE_INDEX"
+    local case_script="$SANDBOX/case-$CASE_INDEX.sh"
+    mkdir -p "$case_home"
+
+    {
+        echo 'set -euo pipefail'
+        echo "source '$LIB'"
+        echo "$body"
+    } > "$case_script"
+
+    local output
+    if output=$(HOME="$case_home" bash "$case_script" 2>&1); then
+        echo "[test-remove-dependencies] PASS: $description" >&2
+    else
+        echo "[test-remove-dependencies] FAIL: $description" >&2
+        [ -n "$output" ] && echo "$output" >&2
+        EXIT_CODE=1
+    fi
+}
+
+run_case "removes a path inside \$HOME" "$(cat <<'CASE'
+# given
+mkdir -p "$HOME/.doomed"
+touch "$HOME/.doomed/config.json"
+
+# when
+apply_tombstones "path:$HOME/.doomed" >/dev/null 2>&1
+
+# then
+[[ ! -e "$HOME/.doomed" ]]
+CASE
+)"
+
+run_case "refuses to remove a path outside \$HOME" "$(cat <<'CASE'
+# given
+outside=$(mktemp -d)
+trap 'rm -rf "$outside"' EXIT
+touch "$outside/precious.txt"
+
+# when
+output=$(apply_tombstones "path:$outside" 2>&1)
+
+# then
+[[ -e "$outside/precious.txt" ]]
+grep -q 'refusing to remove' <<<"$output"
+CASE
+)"
+
+run_case "refuses to remove a bare \$HOME" "$(cat <<'CASE'
+# given
+touch "$HOME/precious.txt"
+
+# when
+apply_tombstones "path:$HOME" >/dev/null 2>&1
+
+# then
+[[ -e "$HOME/precious.txt" ]]
+CASE
+)"
+
+run_case "stays silent when every target is already absent" "$(cat <<'CASE'
+# given
+absent="$HOME/.never-existed"
+
+# when
+output=$(apply_tombstones "path:$absent" 2>&1)
+
+# then
+[[ -z "$output" ]]
+CASE
+)"
+
+run_case "warns on an unknown strategy without skipping later tombstones" "$(cat <<'CASE'
+# given
+mkdir -p "$HOME/.doomed"
+
+# when
+output=$(apply_tombstones "bogus_strategy:whatever" "path:$HOME/.doomed" 2>&1)
+
+# then
+grep -q 'unknown removal strategy' <<<"$output"
+[[ ! -e "$HOME/.doomed" ]]
+CASE
+)"
+
+run_case "no-ops when the underlying package manager is unavailable" "$(cat <<'CASE'
+# given
+export PATH="$HOME/empty-path"
+
+# when
+output=$(apply_tombstones "npm_global:@example/absent" "pipx:absent" 2>&1)
+
+# then
+[[ -z "$output" ]]
+CASE
+)"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+    echo "[test-remove-dependencies] all dependency removal tests passed" >&2
+fi
+
+exit $EXIT_CODE

--- a/.github/ci/scripts/test-remove-dependencies.sh
+++ b/.github/ci/scripts/test-remove-dependencies.sh
@@ -87,6 +87,48 @@ apply_tombstones "path:$HOME" >/dev/null 2>&1
 CASE
 )"
 
+run_case "refuses a path that escapes \$HOME via a '..' component" "$(cat <<'CASE'
+# given
+mkdir -p "$HOME/sub"
+touch "$HOME/precious.txt"
+
+# when: satisfies the "$HOME/" prefix check but climbs back out
+output=$(apply_tombstones "path:$HOME/sub/../precious.txt" 2>&1)
+
+# then
+[[ -e "$HOME/precious.txt" ]]
+grep -q 'component' <<<"$output"
+CASE
+)"
+
+run_case "still removes a legitimate path whose name merely contains dots" "$(cat <<'CASE'
+# given
+mkdir -p "$HOME/foo..bar"
+
+# when
+apply_tombstones "path:$HOME/foo..bar" >/dev/null 2>&1
+
+# then
+[[ ! -e "$HOME/foo..bar" ]]
+CASE
+)"
+
+run_case "reports a failed removal instead of counting it as removed" "$(cat <<'CASE'
+# given: a stub npm that reports the package installed but fails to uninstall it
+npm() {
+    [[ "$1" == "uninstall" ]] && return 1
+    return 0
+}
+
+# when
+output=$(apply_tombstones "npm_global:@example/stuck" 2>&1)
+
+# then
+grep -q 'failed to remove' <<<"$output"
+! grep -q 'leftover dependency entries' <<<"$output"
+CASE
+)"
+
 run_case "stays silent when every target is already absent" "$(cat <<'CASE'
 # given
 absent="$HOME/.never-existed"

--- a/.github/ci/scripts/test-script-order.sh
+++ b/.github/ci/scripts/test-script-order.sh
@@ -17,7 +17,10 @@ check_order() {
     local actual=()
     while IFS= read -r line; do
         actual+=("$(basename "$line")")
-    done < <(find "$SCRIPTS_DIR" -name "run_once_before_${platform}-*" -type f | sort)
+    # LC_ALL=C is required: chezmoi orders scripts by Go byte comparison, whereas
+    # a locale-aware sort (e.g. en_US.UTF-8) ignores the '-' separator and would
+    # place "001a-create-op-wrapper" before "001-create-wrapper".
+    done < <(find "$SCRIPTS_DIR" -name "run_once_before_${platform}-*" -type f | LC_ALL=C sort)
 
     # Verify each expected prefix appears in order
     local last_idx=-1

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -156,8 +156,9 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 - `encrypted_*.age`: Encrypted files using age encryption (format: "age encrypted file, ASCII armored")
 - `.chezmoi.yaml.tmpl`: Main chezmoi config — sets age encryption and platform-specific `op` command path
 - `.chezmoiignore`: Platform-conditional file exclusion (uses Go templates with `.chezmoi.os`)
+- `.chezmoiremove`: Target paths deleted from the home directory on every apply (see "Removing a Dependency")
 - `.chezmoiscripts/`: Automated setup and configuration scripts (numbered for execution order)
-- `.chezmoitemplates/`: Shared template fragments (`lib-install-fonts.sh`, `username.tmpl`)
+- `.chezmoitemplates/`: Shared template fragments (`lib-install-fonts.sh`, `lib-remove-dependencies.sh`, `username.tmpl`)
 - `AppData/`: Windows-specific app config files deployed via `run_after_windows-003-copy-app-data-files.ps1.tmpl`
 
 ### Key Managed Files
@@ -294,6 +295,18 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 4. **Always verify**: Check file appears correctly in home directory
 5. Update `.chezmoiignore` if the file should be excluded on certain platforms
 
+### Removing a Dependency
+This repository is a sync, not a bootstrapper. Deleting an `install_*()` function only stops *new* machines from installing the tool — machines that already ran the installer keep it forever, because chezmoi has no concept of packages and no history of the source state.
+
+1. Delete the `install_*()` function (or package-list entry) from the platform's `run_once_before_*-install-dependencies.*` script
+2. Add a `"<strategy>:<target>"` tombstone to `.chezmoiscripts/run_onchange_after_<platform>-*-remove-dependencies.*` for **every** platform that installed it, commenting the removing commit
+3. Add any orphaned config directory to `.chezmoiremove`
+4. Run `make test-remove-dependencies`
+
+Strategies: `apt`, `gh_extension`, `npm_global`, `path`, `pipx` (Linux/Android, defined in `.chezmoitemplates/lib-remove-dependencies.sh`); `npm_global`, `path`, `winget` (Windows, inline). `remove_path` refuses targets outside `$HOME` — never widen that guard, these scripts run unattended.
+
+See `.docs/dependency-lifecycle.md` for the rationale and why Nix/home-manager was rejected.
+
 ### Working with Encrypted Files
 1. Use age encryption for sensitive files
 2. Add encrypted files with: `chezmoi add --encrypt ~/.sensitive-file`
@@ -409,7 +422,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`, `remove-deps`
 
 ## Security and Encryption
 - Private key location: `~/.ssh/chezmoi` (Linux/Windows) or via `op` wrapper (Android)

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -116,6 +116,14 @@ jobs:
       - name: Test modify scripts
         run: make test-modify-scripts
 
+  test-remove-dependencies:
+    name: Test (dependency removal)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test dependency removal library
+        run: make test-remove-dependencies
+
   sast:
     name: SAST
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# SAST, lint, and test reports written by `make sast` / `make lint`
+build/

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,15 @@
+# Gitleaks false-positive suppressions.
+#
+# Entries MUST be full fingerprints in the form <commit>:<file>:<rule>:<line>.
+# Plain <file>:<line> shapes are silently ignored by gitleaks and suppress nothing.
+# Every entry needs a date and a justification for why the match is not a secret.
+
+# 2026-07-22 -- CI fixture for the mock 1Password CLI (`mock-op.sh`), which must
+# return an item shaped like a real `op item get --format json` response so the
+# template-rendering tests exercise the SSH key code path.
+#
+# The GitLab-customised ruleset matches the OPENSSH private key header sentinel
+# alone, with no check on the body. The body here is the literal string
+# `stub-private-key-for-ci-testing` -- there is no key material, and nothing ever
+# parses it. Introduced in a06b0bdc (2026-03-15) and unchanged since.
+a06b0bdc6be29afb768a2abd013f02e357e585f4:.github/ci/fixtures/ssh-item-sample.json:SSH private key:8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,12 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added tombstones retiring Cursor, Gemini CLI, and the deprecated `github/gh-copilot` extension from existing machines, completing the removal started in `601cbeb`
 - added `.docs/dependency-lifecycle.md` documenting the add/remove workflow and recording why Nix/home-manager, Homebrew Bundle, and Ansible were not selected
 - added `make test-remove-dependencies` covering the removal library, including the `$HOME` safety rail that prevents `rm -rf` from escaping the home directory
+- added a repository-level `.gitignore` excluding `build/`, the report directory written by `make sast` and `make lint`
 
 ### Fixed
 
 - fixed `test-script-order.sh` sorting script names with the ambient locale instead of `LC_ALL=C`: under `en_US.UTF-8` the `-` separator is ignored, so `android-001a-create-op-wrapper` sorted before `android-001-create-wrapper` and the test failed even though chezmoi's own byte-order sorting was correct
+- fixed `make sast` failing on a false-positive **SSH private key** in `.github/ci/fixtures/ssh-item-sample.json` by suppressing it by fingerprint in a new `.gitleaksignore`: the GitLab-customised ruleset matches the OPENSSH header sentinel with no check on the body, and the fixture body is the literal string `stub-private-key-for-ci-testing`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added [`ccswitch`](https://github.com/rios0rios0/ccswitch) integration: `install_ccswitch()` installs the CLI and `dot_zshrc.tmpl` starts its monitor daemon and wraps `claude` to rotate between backup Claude accounts when usage limits are exhausted (Linux/WSL, OAuth-based)
 - added the agentic [GitHub Copilot CLI](https://github.com/github/copilot-cli) on all three platforms: `install_copilot_cli()` installs it from the upstream install script into `~/.local/bin` on Linux/WSL and from the `@github/copilot` npm package on Android (best-effort, after `install_nvm`), and Windows installs the `GitHub.Copilot` winget package
 
+- added dependency tombstones so removing a tool from this repository also removes it from machines that already installed it: `run_onchange_after_*-remove-dependencies.*` scripts for Linux/WSL, Windows, and Android, backed by the shared strategy handlers in `.chezmoitemplates/lib-remove-dependencies.sh` (`apt`, `gh_extension`, `npm_global`, `path`, `pipx`, `winget`). Deleting an `install_*()` function only stops new machines from getting a tool — chezmoi has no concept of packages, so uninstallation has to be explicit
+- added `.chezmoiremove` to delete configuration directories orphaned by removed tools (`~/.cursor`, `~/.gemini`), which chezmoi cannot infer from a deleted `dot_*` source file because it has no history of the source state
+- added tombstones retiring Cursor, Gemini CLI, and the deprecated `github/gh-copilot` extension from existing machines, completing the removal started in `601cbeb`
+- added `.docs/dependency-lifecycle.md` documenting the add/remove workflow and recording why Nix/home-manager, Homebrew Bundle, and Ansible were not selected
+- added `make test-remove-dependencies` covering the removal library, including the `$HOME` safety rail that prevents `rm -rf` from escaping the home directory
+
+### Fixed
+
+- fixed `test-script-order.sh` sorting script names with the ambient locale instead of `LC_ALL=C`: under `en_US.UTF-8` the `-` separator is ignored, so `android-001a-create-op-wrapper` sorted before `android-001-create-wrapper` and the test failed even though chezmoi's own byte-order sorting was correct
+
 ### Removed
 
 - removed Gemini CLI (`@google/gemini-cli`) from the Linux/WSL, Windows, and Android dependency installers, together with the Windows npm section that existed only to install it and the orphaned **Gemini API Key** entry in `.docs/mcp-1password-setup.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ make test-template-render           # template rendering with mock 1Password
 make test-chezmoiignore             # platform file inclusion logic
 make test-script-order              # script dependency ordering
 make test-modify-scripts            # modify script (merge) behavior
+make test-remove-dependencies       # dependency removal library (tombstones, $HOME safety rail)
 ```
 
 ## Essential Commands
@@ -48,6 +49,7 @@ chezmoi doctor                      # diagnose installation issues
 | `encrypted_*.age`   | Age-encrypted file, decrypted on apply                 |
 | `run_once_before_*` | Script runs once before file application               |
 | `run_after_*`       | Script runs after every application                    |
+| `run_onchange_after_*` | Script runs after application, only when its own content changes |
 | `private_`          | File deployed with restricted permissions              |
 
 ## Platform Targeting
@@ -152,7 +154,28 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`, `remove-deps`
+
+## Dependency Lifecycle (Removal Is Explicit)
+
+This repository is a **sync**, not a bootstrapper. Deleting an `install_*()` function from a dependency installer only stops *new* machines from getting the tool — machines that already ran it keep it forever. chezmoi has no history of the source state and no concept of packages, so **both halves of a removal must be declared explicitly**.
+
+| Half | Mechanism |
+|------|-----------|
+| Files orphaned in `$HOME` | `.chezmoiremove` (deleted on every apply; patterns are home-relative, `#` starts a comment) |
+| Installed packages | `.chezmoiscripts/run_onchange_after_<platform>-*-remove-dependencies.*` tombstones |
+
+**When removing a dependency, always do all three:**
+
+1. Delete the `install_*()` function (or package-list entry) from the platform installer.
+2. Add a `"<strategy>:<target>"` tombstone to the removal script of **every** platform that installed it, with a comment referencing the removing commit.
+3. Add any orphaned config directory to `.chezmoiremove`.
+
+Strategies live in `.chezmoitemplates/lib-remove-dependencies.sh` (shared by Linux and Android; Windows has its own inline set): `apt`, `gh_extension`, `npm_global`, `path`, `pipx`, `winget`. Every handler is idempotent and silent when the target is already absent.
+
+`remove_path` refuses any target outside `$HOME` — these scripts run unattended, so never widen that guard. `make test-remove-dependencies` covers it.
+
+See `.docs/dependency-lifecycle.md` for the rationale, including why Nix/home-manager was evaluated and rejected (it cannot cover Windows-native or Termux).
 
 ## Important Timing Constraints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,28 @@ development practices, refer to the **[Development Guide](https://github.com/rio
    ```bash
    chezmoi encrypt <file>
    ```
-9. Update `CHANGELOG.md` under `[Unreleased]`
-10. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
-11. Open a pull request against `main`
+9. If your change **removes** a dependency, declare the removal (see below)
+10. Update `CHANGELOG.md` under `[Unreleased]`
+11. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
+12. Open a pull request against `main`
+
+## Removing a Dependency
+
+This repository is a sync, not a bootstrapper. Deleting an `install_*()` function only
+stops *new* machines from installing the tool — every machine that already ran the
+installer keeps it. chezmoi has no concept of packages and no history of the source
+state, so removals must be declared explicitly:
+
+1. Delete the `install_*()` function (or package-list entry) from the platform's
+   `run_once_before_*-install-dependencies.*` script.
+2. Add a `"<strategy>:<target>"` tombstone to
+   `.chezmoiscripts/run_onchange_after_<platform>-*-remove-dependencies.*` for **every**
+   platform that installed it, commenting the removing commit.
+3. Add any orphaned configuration directory to `.chezmoiremove`.
+
+Available strategies: `apt`, `gh_extension`, `npm_global`, `path`, `pipx` (Linux/Android,
+in `.chezmoitemplates/lib-remove-dependencies.sh`) and `npm_global`, `path`, `winget`
+(Windows). Run `make test-remove-dependencies` after touching the removal library.
+
+See [`.docs/dependency-lifecycle.md`](.docs/dependency-lifecycle.md) for the full
+rationale and the alternatives that were evaluated.

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ lint-syntax:
 
 # === Test targets ===
 
-.PHONY: test test-template-render test-chezmoiignore test-script-order test-modify-scripts
+.PHONY: test test-template-render test-chezmoiignore test-script-order test-modify-scripts test-remove-dependencies
 
-test: test-template-render test-chezmoiignore test-script-order test-modify-scripts
+test: test-template-render test-chezmoiignore test-script-order test-modify-scripts test-remove-dependencies
 
 test-template-render:
 	@bash $(CI_DIR)/scripts/test-template-render.sh
@@ -41,6 +41,9 @@ test-script-order:
 
 test-modify-scripts:
 	@bash $(CI_DIR)/scripts/test-modify-scripts.sh
+
+test-remove-dependencies:
+	@bash $(CI_DIR)/scripts/test-remove-dependencies.sh
 
 # === SAST targets ===
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ chezmoi init --apply rios0rios0
 ## Repository Structure
 
 ```
-.chezmoiscripts/         # 30 platform-specific setup scripts (run_once_before_*, run_after_*)
-.chezmoitemplates/       # Shared template fragments (font installer, MCP server logic, username)
+.chezmoiscripts/         # 33 platform-specific setup scripts (run_once_before_*, run_after_*, run_onchange_after_*)
+.chezmoiremove           # Target paths deleted from $HOME on every apply (see Dependency Lifecycle)
+.chezmoitemplates/       # Shared template fragments (font installer, dependency removal, MCP server logic, username)
 dot_claude/              # Claude Code config (settings, permissions, trust) -> ~/.claude/
 dot_config/              # XDG config (mcphub MCP servers for Android) -> ~/.config/
 dot_docker/              # Docker daemon config -> ~/.docker/
@@ -162,10 +163,32 @@ The global `~/.gitignore` (managed via `dot_gitignore`) ignores `.claude/` by de
 | `encrypted_*.age` | Age-encrypted file, decrypted on apply |
 | `run_once_before_*` | Script runs once before file application |
 | `run_after_*` | Script runs after every application |
+| `run_onchange_after_*` | Script runs after application, but only when its own content changes |
 | `private_` | File deployed with restricted permissions |
 | `modify_` | Script that merges changes into an existing file |
 
 Platform-specific scripts are prefixed: `linux-*`, `windows-*`, `android-*`. Exclusion rules in `.chezmoiignore` ensure only the correct platform's files are applied.
+
+## Dependency Lifecycle
+
+This repository is a **sync**, not a bootstrapper: removing something here removes it from every machine, not just from new ones.
+
+chezmoi has no history of the source state and no concept of packages, so neither half of a removal happens automatically. Both are explicit:
+
+| Half | Mechanism | Example |
+|------|-----------|---------|
+| Files left in `$HOME` | `.chezmoiremove` | `~/.cursor` after `dot_cursor/` was deleted |
+| Installed packages | `run_onchange_after_*-remove-dependencies.*` tombstones | `cursor-agent`, `@google/gemini-cli` |
+
+Removing a dependency therefore takes three steps, not one:
+
+1. Delete the `install_*()` function from the platform's dependency installer.
+2. Add a tombstone (`"<strategy>:<target>"`) to the matching removal script for **every** platform that installed it.
+3. Add any orphaned config directory to `.chezmoiremove`.
+
+Strategies (`apt`, `gh_extension`, `npm_global`, `path`, `pipx`, `winget`) live in `.chezmoitemplates/lib-remove-dependencies.sh` and are idempotent, so a clean machine produces no output.
+
+See **[.docs/dependency-lifecycle.md](.docs/dependency-lifecycle.md)** for the full workflow, the known limitations, and why Nix/home-manager, Homebrew Bundle, and Ansible were evaluated and not selected.
 
 ## Debugging
 


### PR DESCRIPTION
## Problem

Deleting an `install_*()` function makes the repository stop installing a tool on **new** machines. It does nothing to machines that already ran the installer.

Verified on a live machine — one day after `601cbeb` removed them:

```
STILL INSTALLED: cursor-agent -> ~/.local/bin/cursor-agent
STILL INSTALLED: gemini       -> ~/.nvm/versions/node/v24.15.0/bin/gemini
                                 (@google/gemini-cli@0.38.1 still in npm -g)
```

These dotfiles were a bootstrapper, not a sync.

## Research: chezmoi does not cover this, by design

The chezmoi maintainer, in [discussion #4650](https://github.com/twpayne/chezmoi/discussions/4650):

> Uninstalling has to be explicit. chezmoi has no concept of brew or packages. chezmoi only knows about scripts.

chezmoi's [declarative-packages guide](https://www.chezmoi.io/user-guide/advanced/install-packages-declaratively/) covers installation only and never mentions removal, because chezmoi ["doesn't know anything about its history, and so can't tell if a file has been removed"](https://www.chezmoi.io/reference/special-files/chezmoiremove/).

## Solution — both halves declared explicitly

| Half | Mechanism |
|------|-----------|
| Files orphaned in `$HOME` | `.chezmoiremove` (`~/.cursor`, `~/.gemini`) |
| Installed packages | `run_onchange_after_*-remove-dependencies.*` tombstones |

Tombstones pair a **strategy** with a **target**:

```bash
TOMBSTONES=(
    # Gemini CLI and Cursor CLI -- removed in 601cbeb (2026-07-21)
    "npm_global:@google/gemini-cli"
    "path:$HOME/.local/bin/cursor-agent"
    "path:$HOME/.local/share/cursor-agent"
)
```

Strategies (`apt`, `gh_extension`, `npm_global`, `path`, `pipx`, `winget`) live in `.chezmoitemplates/lib-remove-dependencies.sh`, shared by Linux and Android as the existing `lib-install-fonts.sh` is. Every handler is idempotent, so a clean machine produces no output. `run_onchange_` means they re-run only when the list changes.

## Why not Nix / home-manager

Recorded in full in `.docs/dependency-lifecycle.md`. Summary: home-manager is the genuinely declarative answer and would be strictly better **where it runs** — but it cannot cover this repository's platform matrix.

| Target | home-manager | Consequence |
|--------|--------------|-------------|
| Kali on WSL | supported | would work |
| Windows 11 native | **not supported** | winget/PowerShell/Oh My Posh/`AppData/` have no Nix story; Nix on Windows exists only inside WSL |
| Termux on Android | only via [nix-on-droid](https://github.com/nix-community/nix-on-droid) | a **fork** of the Termux app, incompatible with the `termux-etc-seccomp` wrapper architecture (`op`, `gh`, `acli`, `claude`) |

Adopting it means abandoning two of three platforms or running two parallel dependency systems. Also rejected: **Homebrew Bundle** (`brew bundle cleanup` is true reconciliation but only sees Homebrew packages — the Linux installer alone uses `apt`, `pip`, `curl | sh`, `npm -g`, `pipx`, and `go install`, plus GVM/SDKMAN/NVM/Pyenv/krew), and **Ansible** (`state: absent` is still a hand-maintained list, with a Python control node added).

## Testing

New `make test-remove-dependencies` (+ CI job), 6 cases in BDD given/when/then form. The library calls `rm -rf` unattended, so the `$HOME` safety rail is covered explicitly:

- removes a path inside `$HOME`
- **refuses a path outside `$HOME`**
- **refuses a bare `$HOME`**
- stays silent when every target is already absent
- warns on an unknown strategy without skipping later tombstones
- no-ops when the package manager is unavailable

Verification performed:

- **Mutation-tested** the safety rail — disabling it makes both rail tests fail, so they are not vacuous
- **`.chezmoiremove` semantics proven empirically** in a sandboxed source/destination pair (`#` really is a comment; a `# keepme` line left `keepme` untouched)
- **PowerShell validated on real Windows** via WSL interop, since `make lint-powershell` skips locally with no `pwsh`: parse-clean (mutation-confirmed the parser reads the file), and the safety rail functionally tested — removed a path under `$HOME`, refused one outside it
- Added `[CmdletBinding(SupportsShouldProcess)]` to the `Remove-*` functions so they satisfy PSScriptAnalyzer's `PSUseShouldProcessForStateChangingFunctions` (Warning severity, which CI treats as failing); PSScriptAnalyzer itself could not be installed locally without admin rights
- Confirmed all three tombstone targets currently match reality on this machine

## Drive-by fix

`test-script-order.sh` sorted script names with the ambient locale. Under `en_US.UTF-8` `sort` ignores the `-` separator, so `android-001a-create-op-wrapper` sorted before `android-001-create-wrapper` and `make test` **failed on `main`**. chezmoi itself sorts by Go byte comparison, so the scripts were always correctly ordered — only the test was wrong. Fixed with `LC_ALL=C sort`.

## Notes for the reviewer

- `.chezmoiremove` entries are **permanent while listed** — if Cursor were ever reinstalled manually, `~/.cursor` would be deleted on the next apply. This is the requested semantics, and it is documented under Known Limitations.
- The tombstone list is append-only and hand-maintained; it is a record of removals, not a diff against a declared set. True reconciliation would mean building a small package manager — documented as the escape hatch if the list becomes unwieldy.
- `apt` removals need passwordless sudo on Linux/WSL; the handler warns and skips rather than blocking an unattended `chezmoi apply` on a password prompt. Termux needs no privilege escalation.
- **Pre-existing and untouched:** gitleaks reports 1 finding in `.github/ci/fixtures/ssh-item-sample.json` from commit `a06b0bdc` (March 2026). Left alone as unrelated to this change; worth a separate fingerprint suppression in `.gitleaksignore`.
- This PR adds exactly 1 new semgrep finding — the `- uses: actions/checkout@v6` in the new CI job, the 12th of 12 identical unpinned-action findings in that file. My new files produce zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)