### PR TITLE
feat(android+shell): added `termux-change-repo` and the `claudex` alias

### DIFF
--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -3,6 +3,10 @@
 # init storage capabilities
 termux-setup-storage
 
+# pick a package mirror before refreshing the lists — the default mirror is regularly
+# unreachable or stale, which makes every `apt` call below fail (interactive dialog)
+termux-change-repo
+
 # update the package list
 apt update
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,6 +94,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 
 #### Android Dependencies (`.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl`)
 - **TIMING**: Takes 45-90 minutes. NEVER CANCEL.
+- Runs `termux-setup-storage` and `termux-change-repo` first (both interactive) so storage is available and a reachable package mirror is selected before any `apt` call
 - Installs Termux packages: git, curl, age, eza, sqlite, vim, neovim, zsh, proot, proot-distro, etc.
 - Sets up `termux-etc-seccomp` wrapper for running pre-compiled Go binaries natively
 - Installs: Oh My Zsh, GVM, terra (custom wrapper for terraform/terragrunt), kubectl (ARM64), SDKMAN, NVM, pyenv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `termux-change-repo` before `apt update` in the Android dependency installer, so a mirror is chosen on a fresh Termux install instead of letting every `apt` call fail against an unreachable or stale default mirror
+- added the `claudex` alias (`claude --dangerously-skip-permissions --effort max`) to `dot_zshrc.tmpl` for Linux/WSL and Android
+
 ## [0.15.0] - 2026-07-22
 
 ### Added

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -405,6 +405,10 @@ source "$HOME/.scripts/linux-engineering-shell-credentials.sh"
 
 ###### Workspace Aliases ###########################################################
 source "$HOME/.scripts/linux-engineering-workspace-aliases.sh"
+
+###### Claude Code #################################################################
+# skips every permission prompt and runs at the highest reasoning effort
+alias claudex="claude --dangerously-skip-permissions --effort max"
 {{- if eq .chezmoi.os "linux" }}
 
 ###### Claude Account Rotation (ccswitch) ##########################################


### PR DESCRIPTION
## Summary

Two additive changes, one per platform surface.

### `termux-change-repo` before the package-list update (Android)

`.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl` went straight from `termux-setup-storage` to `apt update`. On a fresh Termux install the default mirror is regularly unreachable or stale, which makes `apt update` and every `apt install` below it fail. `termux-change-repo` now runs in between so a working mirror is selected first.

It is an interactive dialog, which is consistent with the `termux-setup-storage` call already directly above it.

### `claudex` alias (Linux/WSL + Android)

Added to `dot_zshrc.tmpl`:

```sh
alias claudex="claude --dangerously-skip-permissions --effort max"
```

Placed after the workspace aliases and before the Linux-only `ccswitch` block, so it lands on both zsh platforms. Alias expansion happens before function lookup, so on Linux/WSL `claudex` still routes through the `ccswitch` `claude()` wrapper.

## Validation

- `make lint` — passed (shellcheck, 31/31 templates parsed, embedded Python, YAML/JSON)
- `make test` — passed (template rendering, `.chezmoiignore` platform logic, script order, modify scripts, dependency removal)
- `make sast` — **not run**: the `rios0rios0/pipelines` checkout and `gitleaks` are not available in this Termux environment. CI covers it.
- Rendered `dot_zshrc.tmpl` for both branches and confirmed the alias appears with correct spacing on Android and on Linux (blank line preserved before the `ccswitch` section).

## Docs

- `CHANGELOG.md` — both entries under `[Unreleased] > Added`
- `.github/copilot-instructions.md` — Android dependency section now records the interactive `termux-setup-storage` + `termux-change-repo` preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)