### PR TITLE
fix(android): pinned the SSH agent to a fixed socket path

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -10,6 +10,11 @@
 # `run_onchange_after_*-remove-dependencies.*` scripts.
 # See `.docs/dependency-lifecycle.md`.
 
+# `keychain` state directory -- orphaned when Android switched to a fixed agent
+# socket (`~/.ssh/agent.sock`) managed directly by `dot_zshrc.tmpl`. The stale
+# `<host>-sh` files here only advertise dead random-path sockets.
+.keychain
+
 # Cursor -- removed in 601cbeb (2026-07-21), previously managed as dot_cursor/
 .cursor
 

--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -10,9 +10,10 @@
 # `run_onchange_after_*-remove-dependencies.*` scripts.
 # See `.docs/dependency-lifecycle.md`.
 
-# `keychain` state directory -- orphaned when Android switched to a fixed agent
-# socket (`~/.ssh/agent.sock`) managed directly by `dot_zshrc.tmpl`. The stale
-# `<host>-sh` files here only advertise dead random-path sockets.
+# `keychain` state directory -- removed in 9b19f46 (2026-07-23), orphaned when
+# Android switched to a fixed agent socket (`~/.ssh/agent.sock`) managed
+# directly by `dot_zshrc.tmpl`. The stale `<host>-sh` files here only advertise
+# dead random-path sockets.
 .keychain
 
 # Cursor -- removed in 601cbeb (2026-07-21), previously managed as dot_cursor/

--- a/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_android-002-install-dependencies.sh.tmpl
@@ -63,7 +63,6 @@ utilities=(
     "mlocate"           # it performs file searches (locate and updatedb)
     "openssh"           # used to clone Git repositories and also authentication
     "netcat-openbsd"    # provides `nc` (Termux ships no default), required by SSH `ProxyCommand` blocks in `dot_ssh/config.tmpl`
-    "keychain"          # manages a single long-lived ssh-agent across sessions with a stable socket under `~/.keychain/<host>-sh`; replaces the per-session OMZ `ssh-agent` plugin so child processes (e.g. Claude Code) keep working after the spawning zsh session exits
     "parallel"          # it runs many threads of a command at the same time
     "rsync"             # provides file sync function
     "rclone"            # it's for syncing files with cloud storage (OneDrive, Google Drive, S3, etc.)

--- a/.chezmoiscripts/run_onchange_after_android-004-remove-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_android-004-remove-dependencies.sh.tmpl
@@ -15,6 +15,12 @@ set -euo pipefail
 # Add one group per removal, newest first, and reference the commit that dropped
 # the installer so the entry can be retired once every machine has converged.
 TOMBSTONES=(
+    # `keychain` -- it cannot pin the agent socket path on Termux (it records
+    # whichever random path ssh-agent picked, and ignores a pre-bound
+    # SSH_AUTH_SOCK), so `dot_zshrc.tmpl` now binds the agent itself with
+    # `ssh-agent -a ~/.ssh/agent.sock` and no longer calls it
+    "apt:keychain"
+
     # Gemini CLI -- removed in 601cbeb (2026-07-21)
     "npm_global:@google/gemini-cli"
 

--- a/.chezmoiscripts/run_onchange_after_android-004-remove-dependencies.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_android-004-remove-dependencies.sh.tmpl
@@ -15,10 +15,10 @@ set -euo pipefail
 # Add one group per removal, newest first, and reference the commit that dropped
 # the installer so the entry can be retired once every machine has converged.
 TOMBSTONES=(
-    # `keychain` -- it cannot pin the agent socket path on Termux (it records
-    # whichever random path ssh-agent picked, and ignores a pre-bound
-    # SSH_AUTH_SOCK), so `dot_zshrc.tmpl` now binds the agent itself with
-    # `ssh-agent -a ~/.ssh/agent.sock` and no longer calls it
+    # `keychain` -- removed in 9b19f46 (2026-07-23). It cannot pin the agent
+    # socket path on Termux (it records whichever random path ssh-agent picked,
+    # and ignores a pre-bound SSH_AUTH_SOCK), so `dot_zshrc.tmpl` now binds the
+    # agent itself with `ssh-agent -a ~/.ssh/agent.sock` and no longer calls it
     "apt:keychain"
 
     # Gemini CLI -- removed in 601cbeb (2026-07-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 - added `termux-change-repo` before `apt update` in the Android dependency installer, so a mirror is chosen on a fresh Termux install instead of letting every `apt` call fail against an unreachable or stale default mirror
 - added the `claudex` alias (`claude --dangerously-skip-permissions --effort max`) to `dot_zshrc.tmpl` for Linux/WSL and Android
 
+### Fixed
+
+- fixed signed commits failing on Android with `Couldn't get agent socket?` even from a freshly-opened shell, by pinning the SSH agent to a fixed socket at `~/.ssh/agent.sock` in `dot_zshrc.tmpl` (`ssh-agent -a`) instead of delegating the agent lifecycle to `keychain`. Termux's `ssh-agent` binds a *random* socket path (`~/.ssh/agent/s.<rand>.agent.<rand>`) and `keychain` only records whichever path the agent picked, so every agent restart minted a new path and stranded already-running processes — Claude Code and everything it spawns, tmux servers, IDE helpers — on the dead one. Their environment is fixed at fork time, so opening a fresh zsh could never repair them, which is why the previously-documented "restart the child process" caveat was hit constantly: Android's Phantom Process Killer makes agent death routine. With the path pinned, a restarted agent reclaims the same socket and long-lived children recover on their own. `keychain` cannot do this — it ignores a pre-bound `SSH_AUTH_SOCK` and re-spawns at a random path regardless
+
+### Removed
+
+- removed `keychain` from the Android `utilities` array and stopped calling it in `dot_zshrc.tmpl`, together with the Oh My Zsh `ssh-agent` plugin fallback it guarded (the plugin would spawn a competing per-session agent at a random socket path). Added an `apt:keychain` tombstone and a `.keychain` entry in `.chezmoiremove` so existing machines drop the package and its stale state directory
+
 ## [0.15.0] - 2026-07-22
 
 ### Added

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -99,42 +99,55 @@ slug=$(printf '%s' "$CHEZMOI_DEVICE" \
         -e 's/[[:space:]]\+/-/g' \
   | tr '[:upper:]' '[:lower:]')
 
-# collect only non-.pub identities
+# collect only non-.pub identities (full paths — `ssh-add` does not resolve
+# bare names against ~/.ssh the way `keychain` did)
 typeset -a sshIdentities
 for key in "$HOME/.ssh/$slug"*(.N); do
   if [[ $key != *.pub ]]; then
-    sshIdentities+=${key:t}
+    sshIdentities+=$key
   fi
 done
 
-# Drive the SSH agent with `keychain` instead of the OMZ `ssh-agent` plugin.
-# Why: OMZ's plugin spawns a *per-session* `ssh-agent` at a *random* socket
-# path. Any process launched from that zsh — Claude Code, tmux panes, IDE
-# integrations — inherits `SSH_AUTH_SOCK` at fork time and is left holding a
-# dead socket the moment the originating shell exits, which surfaces as
-# "Couldn't get agent socket?" / "Connection refused" on every signed commit
-# or `git push`. Keychain runs a single long-lived agent across sessions and
-# exposes a stable socket via `~/.keychain/<host>-sh`, so newly-spawned shells
-# always inherit a live `SSH_AUTH_SOCK`. (Note: already-running child
-# processes keep whatever value they inherited at fork time; if keychain
-# does have to restart a dead agent, those long-lived children still need
-# to be restarted to pick up the new socket — the win is for shells started
-# *after* the restart.) `keychain` is provisioned by the Android dependency
-# installer (`run_once_before_android-002-install-dependencies.sh.tmpl`).
+# Pin the SSH agent to a FIXED socket path.
 #
-# Fallback: existing Termux installs that already ran `run_once_before_*`
-# before this change don't have `keychain` yet, and `run_once_before_*`
-# scripts don't rerun on subsequent `chezmoi apply`s. When `keychain` is
-# missing we fall back to the OMZ `ssh-agent` plugin so the user keeps a
-# working agent until they manually `apt install keychain` (or clear
-# chezmoi's `scriptState/` to rerun the installer). Once `keychain` shows
-# up on `$PATH`, the next zsh startup picks it up automatically.
-typeset useKeychain=0
-if (( ${#sshIdentities[@]} > 0 )) && command -v keychain >/dev/null 2>&1; then
-  useKeychain=1
-  eval "$(keychain --eval --quiet "${sshIdentities[@]}")"
-else
-  zstyle ':omz:plugins:ssh-agent' identities $sshIdentities
+# Termux's `ssh-agent` binds a *random* socket path
+# (`~/.ssh/agent/s.<rand>.agent.<rand>`), and nothing that merely *launches*
+# the agent can change that: both the OMZ `ssh-agent` plugin and `keychain`
+# only record whichever path the agent happened to pick. So every agent
+# restart mints a NEW path, and any already-running process that captured
+# `SSH_AUTH_SOCK` at fork time — Claude Code and every command it spawns,
+# tmux servers, IDE helpers — is stranded on the dead one. It surfaces as
+# "Couldn't get agent socket?" / "Connection refused" on every signed commit,
+# and opening a fresh zsh cannot repair an already-running child, because that
+# child's environment was fixed when it forked. Android's Phantom Process
+# Killer makes agent death routine, so this is hit constantly.
+#
+# (`git push` is unaffected either way: `dot_ssh/config.tmpl` authenticates
+# with `IdentityFile` + `IdentitiesOnly yes`, which reads the key off disk and
+# never consults an agent. Only *signing* needs the agent, because
+# `user.signingkey` in `dot_gitconfig.tmpl` is a bare public key, which makes
+# git call `ssh-keygen -Y sign -U` and demand the private half from an agent.)
+#
+# Binding the agent ourselves with `ssh-agent -a <path>` makes restarts
+# transparent: the path never changes, so long-lived children recover the
+# moment a new agent claims the socket. `keychain` cannot do this — it ignores
+# a pre-bound `SSH_AUTH_SOCK` and re-spawns at a random path regardless.
+export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
+if (( ${#sshIdentities[@]} > 0 )); then
+  # `ssh-add -l` exit codes: 0 = agent up with keys, 1 = agent up but empty,
+  # 2 = cannot reach an agent.
+  ssh-add -l >/dev/null 2>&1
+  case $? in
+    2)
+      # Stale or absent socket: drop it and bind a fresh agent to the same path.
+      rm -f "$SSH_AUTH_SOCK"
+      ssh-agent -a "$SSH_AUTH_SOCK" >/dev/null 2>&1 &&
+        ssh-add "${sshIdentities[@]}" >/dev/null 2>&1
+      ;;
+    1)
+      ssh-add "${sshIdentities[@]}" >/dev/null 2>&1
+      ;;
+  esac
 fi
 ######################################################
 {{- end }}
@@ -169,13 +182,9 @@ plugins=(
   python pip pipenv virtualenv pep8
 )
 {{- if eq .chezmoi.os "android" }}
-# Android-only plugins. `keychain` (set up above) replaces the OMZ `ssh-agent`
-# plugin when available; on existing installs that pre-date the keychain
-# switch, fall back to the plugin so the user keeps an agent until the
-# dependency installer reruns or they install `keychain` manually.
-if (( useKeychain == 0 )); then
-  plugins+=(ssh-agent)
-fi
+# Android-only plugins. The OMZ `ssh-agent` plugin is deliberately NOT loaded:
+# the fixed-socket agent bootstrap above owns the agent lifecycle, and the
+# plugin would spawn a competing per-session agent at a random socket path.
 {{- else }}
 # non-Android-only plugins
 plugins+=(command-not-found vim-interaction)

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -104,7 +104,7 @@ slug=$(printf '%s' "$CHEZMOI_DEVICE" \
 typeset -a sshIdentities
 for key in "$HOME/.ssh/$slug"*(.N); do
   if [[ $key != *.pub ]]; then
-    sshIdentities+=$key
+    sshIdentities+=("$key")
   fi
 done
 
@@ -140,12 +140,19 @@ if (( ${#sshIdentities[@]} > 0 )); then
   case $? in
     2)
       # Stale or absent socket: drop it and bind a fresh agent to the same path.
+      # Only `ssh-agent`'s *stdout* is silenced — it emits shell code
+      # (`SSH_AUTH_SOCK=...; export ...`) that must not leak into the startup
+      # output. stderr stays visible on both commands so bind failures, key
+      # errors, and passphrase prompts still reach the user; `ssh-add` writes
+      # everything (including "Identity added") to stderr and nothing to stdout.
+      # This only runs when the agent was actually dead, so it is not per-shell
+      # noise.
       rm -f "$SSH_AUTH_SOCK"
-      ssh-agent -a "$SSH_AUTH_SOCK" >/dev/null 2>&1 &&
-        ssh-add "${sshIdentities[@]}" >/dev/null 2>&1
+      ssh-agent -a "$SSH_AUTH_SOCK" >/dev/null &&
+        ssh-add "${sshIdentities[@]}"
       ;;
     1)
-      ssh-add "${sshIdentities[@]}" >/dev/null 2>&1
+      ssh-add "${sshIdentities[@]}"
       ;;
   esac
 fi


### PR DESCRIPTION
## The bug

Signed commits on Android fail with `Couldn't get agent socket?` / `Connection refused`, **even from a freshly-opened shell** — so the workaround documented in `0.15.0` ("restart the child process") never actually held.

## Root cause

Termux's `ssh-agent` binds a **random** socket path:

```
~/.ssh/agent/s.<rand>.agent.<rand>
```

`keychain` does not pin that path — it only *records* whichever path the agent happened to pick, into `~/.keychain/<host>-sh`. So every agent restart mints a **new** path.

Any process that captured `SSH_AUTH_SOCK` at fork time — Claude Code and every command it spawns, tmux servers, IDE helpers — is then stranded on the dead one. Its environment was fixed when it forked, so **opening a fresh zsh cannot repair it**. Android's Phantom Process Killer makes agent death routine, so this is hit constantly rather than rarely.

Two things made it hard to see:

- `ps`/`pkill` cannot see the agent at all on Android (restricted process visibility), so "no ssh-agent process" readings were misleading — the agent was alive and responding the whole time.
- Only *signing* breaks. `git push` is unaffected, because `dot_ssh/config.tmpl` authenticates with `IdentityFile` + `IdentitiesOnly yes` and never consults an agent. Signing needs it because `user.signingkey` is a bare public key, which makes git call `ssh-keygen -Y sign -U` and demand the private half from an agent.

## The fix

Bind the agent ourselves to a fixed path, so restarts are transparent:

```zsh
export SSH_AUTH_SOCK="$HOME/.ssh/agent.sock"
ssh-add -l >/dev/null 2>&1     # 0 = up w/ keys, 1 = up but empty, 2 = no agent
case $? in
  2) rm -f "$SSH_AUTH_SOCK"
     ssh-agent -a "$SSH_AUTH_SOCK" >/dev/null 2>&1 && ssh-add "${sshIdentities[@]}" ;;
  1) ssh-add "${sshIdentities[@]}" ;;
esac
```

`keychain` is dropped: it **cannot** do this. Verified experimentally — given a live agent pre-bound at a fixed `SSH_AUTH_SOCK`, keychain ignored it and reused its own random-path agent. It is retired via an `apt:keychain` tombstone plus a `.keychain` entry in `.chezmoiremove`, and the OMZ `ssh-agent` plugin fallback it guarded is removed too (that plugin would spawn a competing per-session agent at a random path).

`sshIdentities` now holds full paths — `ssh-add` does not resolve bare names against `~/.ssh` the way keychain did.

## Validation

Ran the **rendered** block from `dot_zshrc.tmpl` in real zsh:

| Scenario | Result |
|---|---|
| Cold start, no socket | agent bound at `~/.ssh/agent.sock`, both keys loaded |
| Re-run with live agent | idempotent no-op, same socket |
| **Agent killed, then fresh shell** | rebinds the **same** path; a process holding only the pre-death path string goes `exit 2` → `exit 0` — **recovered with no restart** |

Also verified `ssh-add -l` exit codes on Termux (`0`/`1`/`2`) match the `case` branches, and **this PR's own commit was signed through the fixed socket** with no key-file override.

- `make lint` — passed
- `make test` — passed
- `make sast` — not run: the `rios0rios0/pipelines` checkout and `gitleaks` are unavailable in this Termux environment. CI covers it.

## Note

Touches the same `[Unreleased]` block as #146, so whichever merges second needs a trivial CHANGELOG conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)