### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -227,7 +227,7 @@ After all `run_once_before_*` scripts, `run_once_after_*` scripts execute once, 
 4. **Cross-platform Validation**:
    - Linux: Verify Zsh + Powerlevel10k configuration
    - Windows: Verify PowerShell profile and Oh My Posh theme
-   - Android: Verify NeoVim and proot wrapper work
+   - Android: Verify NeoVim and `termux-etc-seccomp` wrapper work
    - Test Windows Terminal settings on Windows
 
 5. **Development Tools Test** (after dependency installation):
@@ -428,7 +428,7 @@ Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-key
 ## Security and Encryption
 - Private key location: `~/.ssh/chezmoi` (Linux/Windows) or via `op` wrapper (Android)
 - Age recipients file: `~/.age_recipients` (template: `dot_age_recipients.tmpl`)
-- 1Password integration: Uses `op` CLI; Linux/WSL wraps `op.exe` via `~/.local/bin/op`; Android wraps ARM64 binary via proot Alpine
+- 1Password integration: Uses `op` CLI; Linux/WSL wraps `op.exe` via `~/.local/bin/op`; Android wraps the ARM64 binary (`op_linux_arm64`) via `termux-etc-seccomp` running natively (no proot boundary)
 - SSH commit signing: 1Password `op-ssh-sign` — different binary per platform (`op-ssh-sign-wsl` on WSL, `op-ssh-sign.exe` on Windows, `ssh-keygen` on Android)
 - Git signing keys: Read per-device from 1Password "Device: \<deviceName\>" note (`ssh:` and `gpg:` entries), matched by device hostname
 - **Never commit**: Raw sensitive files — always use encryption or 1Password references

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ### Changed
 
+- refreshed `.github/copilot-instructions.md` to replace two stale `proot Alpine`/`proot wrapper` references for the Android `op` wrapper with `termux-etc-seccomp` (the mechanism it has actually used since 0.4.0), resolving an internal contradiction with the file's own platform matrix
 - changed `claudex` in `dot_zshrc.tmpl` from an alias to a function, so it coexists with the `ccswitch` `claude` wrapper instead of blocking it. zsh refuses to define a function whose name is already an alias — it aborts with `defining function based on alias` and a parse error — so as an alias `claudex` could never gain a body, and re-sourcing `.zshrc` in a shell that still carried the old alias hit the same error. Aliases are also expanded only in interactive shells, which left `claudex` reporting `command not found` in scripts, `zsh -c`, and `sudo zsh -c`; as a function it now resolves there too
 - changed `claude` and `claudex` to share a single `_claude_ensure_account` guard that installs the current account's credentials before launching, so `ccswitch` rotation applies to both entrypoints explicitly. `claudex` previously inherited it only by calling a bare `claude`, which reached the wrapper solely because a bare command word resolves to a function before a binary — rewriting it to `command claude` would have silently dropped rotation from the entrypoint used most. The guard is a no-op when `ccswitch` is not installed
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.