### PR TITLE
fix(tmpdir-modcache): prevented Termux OOM crash from Go module caches in $TMPDIR

### DIFF
--- a/.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh
+++ b/.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh
@@ -1,0 +1,90 @@
+#!/data/data/com.termux/files/usr/bin/bash
+
+# Deletes Go module caches that were created under $TMPDIR.
+#
+# Go writes module cache entries as 0400 files inside 0500 directories, and
+# unlinking a child requires its *parent* to be writable, so a plain `rm -rf`
+# fails with EACCES on every one of them. Termux's TermuxService.onDestroy()
+# calls clearTermuxTMPDIR(), which walks $TMPDIR, collects one stack trace per
+# entry it could not delete, and then stringifies the whole batch. A single
+# leaked cache is ~8k undeletable entries; at roughly 1.5k characters per trace
+# the StringBuilder crosses the 256 MB heap growth limit and Termux dies with
+# an OutOfMemoryError every time it is closed.
+#
+# `dot_zshenv.tmpl` pins GOMODCACHE to $HOME so Go can no longer place a cache
+# here, which is the actual fix. This script is the safety net for what the pin
+# cannot reach: caches left behind by an earlier revision of this repo, and
+# tools that export a GOMODCACHE of their own. Prevention and cleanup are
+# separate jobs and both are needed.
+#
+# Only the `pkg/mod` directory is removed, never its parent, so a sibling `bin/`
+# holding `go install`ed tools survives.
+#
+# This is a `run_after_` (not `run_once_after_`) script so it re-runs on every
+# `chezmoi apply`.
+
+set -euo pipefail
+
+prefix="tmp-modcache"
+
+tmpDir="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+
+[ -d "$tmpDir" ] || exit 0
+
+# Resolve to a canonical path so the containment check below cannot be defeated
+# by a symlink or a trailing slash.
+tmpDir="$(cd "$tmpDir" && pwd -P)"
+
+prune_cache() {
+    local cache="$1"
+
+    # Safety rail: this runs unattended on every apply, so it must never delete
+    # outside $TMPDIR. The `?*` guard also rejects a bare "$tmpDir" itself.
+    case "$cache" in
+        "$tmpDir"/?*) ;;
+        *)
+            echo "[$prefix] WARN: refusing to remove '$cache' (outside \$TMPDIR)" >&2
+            return 0
+            ;;
+    esac
+
+    # No `..` component, which would satisfy the prefix check above yet still
+    # escape $TMPDIR. Wrapping the path in slashes means a real component always
+    # shows up as "/../", so a legitimate name like "foo..bar" is not caught.
+    case "/$cache/" in
+        */../*)
+            echo "[$prefix] WARN: refusing to remove '$cache' (path escapes \$TMPDIR)" >&2
+            return 0
+            ;;
+    esac
+
+    # Never touch the live module cache, however it was configured.
+    if [ -n "${GOMODCACHE:-}" ] && [ "$cache" = "$GOMODCACHE" ]; then
+        echo "[$prefix] WARN: skipping '$cache' (it is the active \$GOMODCACHE)" >&2
+        return 0
+    fi
+
+    echo "[$prefix] removing Go module cache under \$TMPDIR: $cache" >&2
+
+    # Restore write permission before deleting. Without this `rm -rf` fails on
+    # every entry, which is the same wall Termux hits on shutdown.
+    chmod -R u+w "$cache" 2>/dev/null || true
+
+    if ! rm -rf "$cache"; then
+        echo "[$prefix] WARN: failed to remove '$cache'" >&2
+    fi
+}
+
+found=0
+
+# `-prune` stops the descent so the thousands of entries inside a cache are
+# never enumerated. The loop body runs in the current shell (no pipeline), so
+# `found` survives it.
+while IFS= read -r cache; do
+    found=1
+    prune_cache "$cache"
+done < <(find "$tmpDir" -type d -path '*/pkg/mod' -prune -print 2>/dev/null)
+
+if [ "$found" -ne 0 ]; then
+    echo "[$prefix] done" >&2
+fi

--- a/.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh
+++ b/.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh
@@ -35,8 +35,36 @@ tmpDir="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
 # by a symlink or a trailing slash.
 tmpDir="$(cd "$tmpDir" && pwd -P)"
 
+# Resolves a directory to its canonical form so path comparisons are not decided
+# by spelling. Falls back to stripping trailing slashes lexically when the path
+# does not exist, which is the best that can be done without a real directory to
+# resolve.
+canonical_dir() {
+    local path="$1"
+
+    if [ -z "$path" ]; then
+        return 0
+    fi
+
+    if [ -d "$path" ]; then
+        if (cd "$path" 2>/dev/null && pwd -P); then
+            return 0
+        fi
+    fi
+
+    while :; do
+        case "$path" in
+            ?*/) path="${path%/}" ;;
+            *) break ;;
+        esac
+    done
+
+    printf '%s\n' "$path"
+}
+
 prune_cache() {
     local cache="$1"
+    local live=""
 
     # Safety rail: this runs unattended on every apply, so it must never delete
     # outside $TMPDIR. The `?*` guard also rejects a bare "$tmpDir" itself.
@@ -58,10 +86,18 @@ prune_cache() {
             ;;
     esac
 
-    # Never touch the live module cache, however it was configured.
-    if [ -n "${GOMODCACHE:-}" ] && [ "$cache" = "$GOMODCACHE" ]; then
-        echo "[$prefix] WARN: skipping '$cache' (it is the active \$GOMODCACHE)" >&2
-        return 0
+    # Never touch the live module cache, however it was configured. The
+    # comparison is between canonical paths rather than raw strings: a trailing
+    # slash, a relative path or a symlinked component would all name the same
+    # directory while comparing unequal, and this rail failing open means
+    # deleting the one cache it exists to protect.
+    if [ -n "${GOMODCACHE:-}" ]; then
+        live="$(canonical_dir "$GOMODCACHE")"
+
+        if [ -n "$live" ] && [ "$(canonical_dir "$cache")" = "$live" ]; then
+            echo "[$prefix] WARN: skipping '$cache' (it is the active \$GOMODCACHE)" >&2
+            return 0
+        fi
     fi
 
     echo "[$prefix] removing Go module cache under \$TMPDIR: $cache" >&2

--- a/.github/ci/scripts/test-prune-tmp-modcache.sh
+++ b/.github/ci/scripts/test-prune-tmp-modcache.sh
@@ -95,6 +95,28 @@ else
     fail "refuses to remove the active \$GOMODCACHE (script errored)"
 fi
 
+# The rail must key on the directory, not on how it was spelled. Each of these
+# names the same cache as the one `find` reports, so a raw string comparison
+# would fail open and delete it.
+new_case
+make_cache "$CASE_TMP/live"
+GOMODCACHE="$CASE_TMP/live/pkg/mod/" TMPDIR="$CASE_TMP" bash "$SCRIPT" >/dev/null 2>&1 || true
+check "refuses when \$GOMODCACHE carries a trailing slash" \
+      "$([ -d "$CASE_TMP/live/pkg/mod" ] && echo true || echo false)"
+
+new_case
+make_cache "$CASE_TMP/live"
+ln -sfn "$CASE_TMP/live" "$CASE_TMP/live-link"
+GOMODCACHE="$CASE_TMP/live-link/pkg/mod" TMPDIR="$CASE_TMP" bash "$SCRIPT" >/dev/null 2>&1 || true
+check "refuses when \$GOMODCACHE reaches the cache through a symlink" \
+      "$([ -d "$CASE_TMP/live/pkg/mod" ] && echo true || echo false)"
+
+new_case
+make_cache "$CASE_TMP/live"
+GOMODCACHE="$CASE_TMP/live/pkg/mod/../mod" TMPDIR="$CASE_TMP" bash "$SCRIPT" >/dev/null 2>&1 || true
+check "refuses when \$GOMODCACHE contains a '..' component" \
+      "$([ -d "$CASE_TMP/live/pkg/mod" ] && echo true || echo false)"
+
 # --- does not escape $TMPDIR through a symlink -------------------------------
 new_case
 mkdir -p "$CASE_DIR/outside/pkg/mod"

--- a/.github/ci/scripts/test-prune-tmp-modcache.sh
+++ b/.github/ci/scripts/test-prune-tmp-modcache.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -euo pipefail
+
+# Exercises .chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh. This
+# script calls `rm -rf` unattended on every apply, so the $TMPDIR safety rail,
+# the refusal to delete a live cache, and the no-op-when-clean behaviour are
+# covered explicitly.
+#
+# The script is invoked through `bash` rather than executed, because its shebang
+# points at Termux's bash and CI runs on Linux.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SCRIPT="$REPO_ROOT/.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh"
+EXIT_CODE=0
+CASE_INDEX=0
+
+echo "[test-prune-tmp-modcache] testing \$TMPDIR module cache pruning..." >&2
+
+if [ ! -f "$SCRIPT" ]; then
+    echo "[test-prune-tmp-modcache] FAIL: script not found at $SCRIPT" >&2
+    exit 1
+fi
+
+SANDBOX=$(mktemp -d)
+# The fixtures deliberately contain read-only directories, so restore write
+# permission before cleaning up or the trap cannot remove them either.
+trap 'chmod -R u+w "$SANDBOX" 2>/dev/null || true; rm -rf "$SANDBOX"' EXIT
+
+pass() { echo "[test-prune-tmp-modcache] PASS: $1" >&2; }
+fail() { echo "[test-prune-tmp-modcache] FAIL: $1" >&2; EXIT_CODE=1; }
+
+check() {
+    local description="$1"
+    local condition="$2"
+
+    if [ "$condition" = "true" ]; then
+        pass "$description"
+    else
+        fail "$description"
+    fi
+}
+
+# Builds a leaked Go module cache with Go's real permissions: 0400 files inside
+# 0500 directories, which cannot be unlinked until the parent is writable again.
+make_cache() {
+    local root="$1"
+
+    mkdir -p "$root/pkg/mod/github.com/foo@v1.0.0/sub"
+    echo "package foo" > "$root/pkg/mod/github.com/foo@v1.0.0/sub/foo.go"
+    chmod 0400 "$root/pkg/mod/github.com/foo@v1.0.0/sub/foo.go"
+    chmod 0500 "$root/pkg/mod/github.com/foo@v1.0.0/sub" \
+               "$root/pkg/mod/github.com/foo@v1.0.0"
+}
+
+new_case() {
+    CASE_INDEX=$((CASE_INDEX + 1))
+    CASE_DIR="$SANDBOX/case-$CASE_INDEX"
+    CASE_TMP="$CASE_DIR/tmp"
+    mkdir -p "$CASE_TMP"
+}
+
+# --- the fixture must actually reproduce the failure it guards against --------
+new_case
+make_cache "$CASE_TMP/proj/.go"
+if rm -rf "$CASE_TMP/proj/.go/pkg/mod" 2>/dev/null && [ ! -d "$CASE_TMP/proj/.go/pkg/mod" ]; then
+    fail "fixture reproduces an undeletable cache (plain rm -rf should fail)"
+else
+    pass "fixture reproduces an undeletable cache (plain rm -rf fails)"
+fi
+
+# --- removes the cache, keeps everything else --------------------------------
+new_case
+make_cache "$CASE_TMP/proj/.go"
+mkdir -p "$CASE_TMP/proj/.go/bin"
+echo "binary" > "$CASE_TMP/proj/.go/bin/gotestsum"
+
+if TMPDIR="$CASE_TMP" bash "$SCRIPT" >/dev/null 2>&1; then
+    pass "exits 0 after pruning a cache"
+else
+    fail "exits 0 after pruning a cache"
+fi
+check "removes a read-only module cache under \$TMPDIR" \
+      "$([ ! -d "$CASE_TMP/proj/.go/pkg/mod" ] && echo true || echo false)"
+check "leaves a sibling bin/ untouched" \
+      "$([ -f "$CASE_TMP/proj/.go/bin/gotestsum" ] && echo true || echo false)"
+
+# --- refuses to delete the live cache ----------------------------------------
+new_case
+make_cache "$CASE_TMP/live"
+
+if GOMODCACHE="$CASE_TMP/live/pkg/mod" TMPDIR="$CASE_TMP" bash "$SCRIPT" >/dev/null 2>&1; then
+    check "refuses to remove the active \$GOMODCACHE" \
+          "$([ -d "$CASE_TMP/live/pkg/mod" ] && echo true || echo false)"
+else
+    fail "refuses to remove the active \$GOMODCACHE (script errored)"
+fi
+
+# --- does not escape $TMPDIR through a symlink -------------------------------
+new_case
+mkdir -p "$CASE_DIR/outside/pkg/mod"
+echo "precious" > "$CASE_DIR/outside/pkg/mod/precious.txt"
+ln -sfn "$CASE_DIR/outside" "$CASE_TMP/escape"
+
+TMPDIR="$CASE_TMP" bash "$SCRIPT" >/dev/null 2>&1 || true
+check "does not follow a symlink out of \$TMPDIR" \
+      "$([ -f "$CASE_DIR/outside/pkg/mod/precious.txt" ] && echo true || echo false)"
+
+# --- quiet no-ops -------------------------------------------------------------
+new_case
+output=$(TMPDIR="$CASE_TMP" bash "$SCRIPT" 2>&1) && rc=0 || rc=$?
+check "exits 0 when there is nothing to prune" "$([ "$rc" -eq 0 ] && echo true || echo false)"
+check "stays silent when there is nothing to prune" "$([ -z "$output" ] && echo true || echo false)"
+
+new_case
+if TMPDIR="$CASE_DIR/does-not-exist" bash "$SCRIPT" >/dev/null 2>&1; then
+    pass "exits 0 when \$TMPDIR does not exist"
+else
+    fail "exits 0 when \$TMPDIR does not exist"
+fi
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+    echo "[test-prune-tmp-modcache] all module cache pruning tests passed" >&2
+fi
+
+exit $EXIT_CODE

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -124,6 +124,14 @@ jobs:
       - name: Test dependency removal library
         run: make test-remove-dependencies
 
+  test-prune-tmp-modcache:
+    name: Test (TMPDIR module cache pruning)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test TMPDIR module cache pruning
+        run: make test-prune-tmp-modcache
+
   sast:
     name: SAST
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed Termux crashing with an `OutOfMemoryError` every time it was closed on Android, by pinning `GOMODCACHE` to `$HOME/go/pkg/mod` in `dot_zshenv.tmpl` and adding `.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh` to sweep up any Go module cache still found under `$TMPDIR`. Go derives `GOMODCACHE` from `GOPATH`, and the pipelines Go scripts set `GOPATH="$(pwd)/.go"` when it is unset, so running `make test` from a directory inside `$TMPDIR` — Claude Code scratchpads live at `$TMPDIR/claude-<pid>/...` — created the module cache there. Go writes those entries as `0400` files inside `0500` directories and unlinking a child needs its *parent* writable, so nothing can delete them without a `chmod` first; a plain `rm -rf` fails with `EACCES` on every entry. Termux's `TermuxService.onDestroy()` calls `clearTermuxTMPDIR()`, which collects one stack trace per entry it cannot remove and then stringifies the batch, so the failure surfaced as `java.lang.OutOfMemoryError` inside `Logger.getStackTracesString` rather than anywhere near Go. Three leaked caches totalling 16,332 undeletable entries had accumulated in `$TMPDIR` (502 MB across 25,537 files), and at roughly 1.5k characters per trace the `StringBuilder` asked for 98,865,176 bytes against a 256 MB heap growth limit. Two crash reports five days apart requested that byte count *exactly* — the giveaway that the input was a fixed, undeletable file set rather than genuine memory pressure. Pinning the cache is safe because it is content-addressed and immutable, which is why `GOMODCACHE` was split out of `GOPATH` in Go 1.15; GVM pkgset isolation still applies to `bin/`, which is what it is actually for. Both halves are required, since the pin cannot retroactively remove caches left by earlier revisions nor reach a tool that exports its own `GOMODCACHE`
+
 ## [0.16.2] - 2026-08-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ make test-chezmoiignore             # platform file inclusion logic
 make test-script-order              # script dependency ordering
 make test-modify-scripts            # modify script (merge) behavior
 make test-remove-dependencies       # dependency removal library (tombstones, $HOME safety rail)
+make test-prune-tmp-modcache        # $TMPDIR Go module cache pruning ($TMPDIR safety rail)
 ```
 
 ## Essential Commands
@@ -154,7 +155,7 @@ All scripts and templates use a standardized `[prefix]` logging format to stderr
 | PowerShell (`.ps1`) | `Write-Host "[prefix] message"` |
 | Python (in `modify_*`) | `print("[prefix] message", file=sys.stderr)` |
 
-Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`, `remove-deps`
+Existing prefixes: `gitconfig`, `ssh-config`, `allowed-signers`, `authorized-keys`, `docker-config`, `wakatime`, `age-recipients`, `android-ssh-keys`, `linux-gpg-keys`, `windows-ssh-keys`, `windows-pem-keys`, `wrapper`, `op-wrapper`, `gh-wrapper`, `acli-wrapper`, `golangci-lint-wrapper`, `claude-wrapper`, `copilot`, `export-key`, `extract-folders`, `clone-tools`, `configure-deps`, `ssh-known-hosts`, `copy-appdata`, `termux-config`, `fonts`, `kube-config`, `mcp-servers`, `claude-trust`, `claude-settings`, `claude-code-patch`, `ggshield-auth`, `ggshield-hook`, `jetbrains-themes`, `acli`, `send`, `credentials`, `workspaces`, `dev-toolkit`, `aws-cli`, `azure-cli`, `golangci-lint`, `sync-repo`, `install-deps`, `remove-deps`, `tmp-modcache`
 
 ## Dependency Lifecycle (Removal Is Explicit)
 
@@ -212,6 +213,23 @@ Android 12+ includes a **Phantom Process Killer** that enforces a system-wide li
 **Diagnosing a phantom kill:** count forked children with `ps -A -o pid,ppid,cmd | grep com.termux | wc -l`. At ~30 you are saturated regardless of free RAM — check `free -m` to rule out real memory pressure, then look for orphans (`ppid == 1`) that should have been reaped.
 
 **Manual Android settings:** Exclude Termux from battery optimization (`Unrestricted`), set animation scales to `0.5x`, enable RAM Plus if available.
+
+### Never Let a Go Module Cache Land in `$TMPDIR`
+
+Termux clears `$TMPDIR` from `TermuxService.onDestroy()`. That routine collects one stack trace per entry it fails to delete and then stringifies the whole batch, so a directory full of undeletable files turns app shutdown into an `OutOfMemoryError` — the heap growth limit is 256 MB and ~16k failures produced a 98 MB string.
+
+Go module caches are exactly that kind of directory: entries are written as `0400` files inside `0500` directories, and unlinking a child needs its *parent* writable, so `rm -rf` fails with `EACCES` on every one. Anything cleaning `$TMPDIR` hits the same wall.
+
+They get there because Go derives `GOMODCACHE` from `GOPATH`, and the pipelines Go scripts set `GOPATH="$(pwd)/.go"` when it is unset. Run `make test` with a cwd under `$TMPDIR` — Claude Code scratchpads live at `$TMPDIR/claude-<pid>/...` — and the cache is created there.
+
+| Half | Mechanism |
+|------|-----------|
+| Prevention | `dot_zshenv.tmpl` exports `GOMODCACHE="$HOME/go/pkg/mod"`, so no `GOPATH` a script picks can move the cache |
+| Cleanup | `.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh` chmods and removes any `*/pkg/mod` still found under `$TMPDIR` |
+
+Both are needed: the pin cannot retroactively remove caches left by older revisions, nor reach a tool that exports its own `GOMODCACHE`. When deleting one by hand, always `chmod -R u+w` first.
+
+**Diagnosing it:** `find "$TMPDIR" ! -writable | wc -l`. Anything in the thousands will crash Termux on exit. A telltale sign in the crash report is an *identical* allocation size across separate crashes — the file set is unchanged, so the string is deterministic.
 
 ## AI Rules Sync
 

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ lint-syntax:
 
 # === Test targets ===
 
-.PHONY: test test-template-render test-chezmoiignore test-script-order test-modify-scripts test-remove-dependencies
+.PHONY: test test-template-render test-chezmoiignore test-script-order test-modify-scripts test-remove-dependencies test-prune-tmp-modcache
 
-test: test-template-render test-chezmoiignore test-script-order test-modify-scripts test-remove-dependencies
+test: test-template-render test-chezmoiignore test-script-order test-modify-scripts test-remove-dependencies test-prune-tmp-modcache
 
 test-template-render:
 	@bash $(CI_DIR)/scripts/test-template-render.sh
@@ -44,6 +44,9 @@ test-modify-scripts:
 
 test-remove-dependencies:
 	@bash $(CI_DIR)/scripts/test-remove-dependencies.sh
+
+test-prune-tmp-modcache:
+	@bash $(CI_DIR)/scripts/test-prune-tmp-modcache.sh
 
 # === SAST targets ===
 

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -147,6 +147,30 @@ if [[ -z "$GOPATH" && -d "$HOME/go/bin" ]]; then
 fi
 {{- end }}
 
+# Pin the Go module cache to $HOME instead of letting Go derive it from
+# whatever GOPATH happens to be set.
+#
+# Go defaults GOMODCACHE to "$GOPATH/pkg/mod", so any script that repoints
+# GOPATH drags the module cache along with it. The pipelines Go scripts do
+# exactly that -- `GOPATH="$(pwd)/.go"` when GOPATH is unset -- which puts the
+# cache wherever the caller happened to be standing. Run one from a directory
+# inside $TMPDIR (Claude Code scratchpads live at $TMPDIR/claude-<pid>/...) and
+# the cache is created there.
+#
+# That is fatal on Android. Go writes module entries as 0400 files inside 0500
+# directories, and unlinking a child needs its *parent* writable, so nothing can
+# delete them without a chmod first. Termux's TermuxService.onDestroy() calls
+# clearTermuxTMPDIR(), which collects one stack trace per entry it fails to
+# remove and then stringifies the batch -- ~16k undeletable entries produced a
+# 98 MB string against a 256 MB heap limit and Termux died with an
+# OutOfMemoryError every time it was closed.
+#
+# Pinning is safe: the module cache is content-addressed and immutable, so
+# sharing one across GOPATHs and GVM pkgsets is the intended arrangement (it is
+# why GOMODCACHE was split out of GOPATH in Go 1.15). Pkgset isolation still
+# applies to bin/, which is what it is actually for.
+export GOMODCACHE="$HOME/go/pkg/mod"
+
 # Pyenv - Python version manager
 pyenvRoot="$HOME/.pyenv"
 if [[ -d "$pyenvRoot" ]]; then


### PR DESCRIPTION
## Problem

Termux was crashing with `java.lang.OutOfMemoryError` every time it was closed:

```
Failed to allocate a 98865176 byte allocation with 38101328 free bytes and 36MB until OOM
  at com.termux.shared.logger.Logger.getStackTracesString(Logger.java:323)
  at com.termux.shared.shell.TermuxShellUtils.clearTermuxTMPDIR(TermuxShellUtils.java:196)
  at com.termux.app.TermuxService.onDestroy(TermuxService.java:167)
```

Two crash reports five days apart requested that byte count **exactly**. That is the tell: the input was a fixed, undeletable file set, not genuine memory pressure.

## Root cause

1. Go derives `GOMODCACHE` from `GOPATH`, and the pipelines Go scripts set `GOPATH="$(pwd)/.go"` when it is unset.
2. Run `make test` with a cwd under `$TMPDIR` — Claude Code scratchpads live at `$TMPDIR/claude-<pid>/...` — and the module cache is created there.
3. Go writes those entries as `0400` files inside `0500` directories. Unlinking a child requires its **parent** to be writable, so a plain `rm -rf` fails with `EACCES` on every one:

   ```
   rm: cannot remove '.../pkg/mod/github.com/!cyclone!d!x/cyclonedx-gomod@v1.10.0/.gitignore': Permission denied
   ```

4. `TermuxService.onDestroy()` calls `clearTermuxTMPDIR()`, which collects one stack trace per failed entry and then stringifies the batch. It surfaces as an OOM inside `Logger.getStackTracesString`, nowhere near Go.

On the affected device `$TMPDIR` held three leaked caches: **502 MB across 25,537 files, 16,332 of them undeletable**. At roughly 1.5k characters per trace the `StringBuilder` asked for 98,865,176 bytes against a 256 MB heap growth limit.

## Fix

Prevention and cleanup are separate jobs and both are needed — the pin cannot retroactively remove caches left by earlier revisions, nor reach a tool that exports its own `GOMODCACHE`.

| Half | Mechanism |
|------|-----------|
| Prevention | `dot_zshenv.tmpl` exports `GOMODCACHE="$HOME/go/pkg/mod"` |
| Cleanup | `.chezmoiscripts/run_after_android-005-prune-tmp-modcache.sh` chmods and removes any `*/pkg/mod` under `$TMPDIR` |

Pinning is safe: the module cache is content-addressed and immutable, which is why `GOMODCACHE` was split out of `GOPATH` in Go 1.15. GVM pkgset isolation still applies to `bin/`, which is what it is actually for.

The pruning script only removes `pkg/mod`, never its parent, so a sibling `bin/` of `go install`ed tools survives. It carries a `$TMPDIR` containment rail (mirroring the `$HOME` rail in `lib-remove-dependencies.sh`) and refuses to touch the live `$GOMODCACHE`.

## Verification

`make test-prune-tmp-modcache` (new, wired into `make test` and CI) covers 9 cases, including a fixture that asserts a plain `rm -rf` **fails** first, so the test cannot silently stop exercising the condition it guards.

Mutation-tested — removing the `chmod` or the live-cache rail each turns the suite red:

```
MUTATION: drop the chmod        -> FAIL: removes a read-only module cache under $TMPDIR
MUTATION: drop the rail         -> FAIL: refuses to remove the active $GOMODCACHE
```

`make lint` and `make test` pass. **`make sast` could not be run on the affected device**: the local pipelines clone is missing `global/scripts/tools/*/run.sh`, and `gitleaks` dies with `SIGSYS: bad system call` on `faccessat2` (the Android seccomp issue `termux-etc-seccomp` wraps for other tools) — it still crashes through the wrapper. Both are pre-existing and unrelated to this change; CI runs SAST on `ubuntu-latest`.

Live `$TMPDIR` on the affected device went from **502 MB / 25,537 entries / 16,332 undeletable** to **2.8 MB / 93 entries / 0 undeletable**.