### PR TITLE
fix(chezmoiignore): removed leading slash that aborted every apply

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -4,7 +4,7 @@
 .github
 .shellcheckrc
 CHANGELOG.md
-/CLAUDE.md
+CLAUDE.md
 CONTRIBUTING.md
 LICENSE
 Makefile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `chezmoi apply` aborting on every platform with `.chezmoiignore:7: /CLAUDE.md: invalid path` by dropping the leading slash from the `CLAUDE.md` ignore pattern. chezmoi matches ignore patterns against the target path *relative* to the destination directory, so a leading `/` makes the pattern an absolute path and is rejected. The entry was written as `/CLAUDE.md` in `0a21e6d` (2026-03-07) and older chezmoi releases tolerated it; the Termux package moved 2.70.5 → 2.71.1 → 2.72.0 between the last successful apply on 2026-07-22 and the next one on 2026-08-11, and the newer binary validates the pattern at parse time. Because `.chezmoiignore` is read before anything else, the failure aborted the whole run rather than skipping one file — the `chezmoi update` that shipped 0.16.3 pulled the commits but applied none of them, so the `$TMPDIR` module-cache guard from that release silently never reached the device it was written for. Removing the slash is behaviour-preserving: unlike `.gitignore`, a chezmoi pattern with no slash is already anchored to the destination root, so `CLAUDE.md` still matches `~/CLAUDE.md` and not `~/any/dir/CLAUDE.md`, which is exactly what the slash was there to express. Every neighbouring entry in the same block (`CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE`, `Makefile`, `README.md`) was already slash-free
+
 ## [0.16.3] - 2026-08-11
 
 ### Fixed


### PR DESCRIPTION
## Problem

`chezmoi apply` / `chezmoi update` fails on **every platform** before doing any work:

```
chezmoi: ~/.local/share/chezmoi/.chezmoiignore:7: /CLAUDE.md: invalid path
```

chezmoi matches `.chezmoiignore` patterns against the target path *relative* to the destination
directory, so the leading `/` makes the pattern an absolute path and it is rejected at parse time.

## Why it surfaced now

The entry was written as `/CLAUDE.md` back in `0a21e6d` (2026-03-07) and older chezmoi releases
tolerated it. The Termux package moved `2.70.5` → `2.71.1` (22 Jul) → `2.72.0` (4 Aug) between the
last successful apply on 2026-07-22 and the next one on 2026-08-11, and the newer binary validates
the pattern.

## Impact

`.chezmoiignore` is read before anything else, so the failure aborted the **whole run** rather than
skipping a single file. The `chezmoi update` that shipped `0.16.3` pulled the commits but applied
none of them — the `$TMPDIR` Go module cache guard from that release silently never reached the
Android device it was written for (`grep -c GOMODCACHE ~/.zshenv` → `0`, and
`run_after_android-005-prune-tmp-modcache.sh` had never run).

## Fix

Drop the slash. This is behaviour-preserving: unlike `.gitignore`, a chezmoi pattern with no slash
is **already** anchored to the destination root, which is exactly what the slash was there to
express. Every neighbouring entry in the same block (`CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE`,
`Makefile`, `README.md`) was already slash-free.

Verified against chezmoi `2.72.0` in a throwaway source tree — with a source containing both
`CLAUDE.md` and `dir/CLAUDE.md`:

```
managed → .keepme, dir, dir/CLAUDE.md      # root CLAUDE.md ignored, nested one kept
```

The union of all 45 patterns across every OS branch of the file now parses with exit `0`, and
`make lint-templates` reports `31/31 templates parsed successfully`.

## Follow-up (not in this PR)

`make lint` validates Go template *syntax* but never asks chezmoi whether the rendered patterns are
valid, which is why this shipped. A parse check in `.github/ci` would catch the next one.