### PR TITLE
fix(claude): restored the required `id-token: write` permission

### DIFF
--- a/.changes/unreleased/1787880000000000033-b021.yaml
+++ b/.changes/unreleased/1787880000000000033-b021.yaml
@@ -1,0 +1,3 @@
+kind: 'Fixed'
+body: 'restored the `id-token: write` permission on both Claude workflow callers. Without it the caller grants less than the reusable workflow declares, which GitHub rejects before the job starts -- runs ended in `startup_failure`. The action needs the scope because `setupGitHubToken()` exchanges a GitHub OIDC token for the GitHub App token it posts with, unless a `github_token` is passed explicitly.'
+time: '2026-08-27T22:30:00.000000000Z'

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -19,4 +19,5 @@ jobs:
       contents: 'write'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'
       actions: 'read'

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -13,3 +13,4 @@ jobs:
       contents: 'read'
       pull-requests: 'write'
       issues: 'write'
+      id-token: 'write'


### PR DESCRIPTION
## 🚨 The Claude workflows here cannot start without this

`id-token: write` was removed from both callers by the previous PR. That was my error, and the effect is not subtle — runs fail at **startup**:

```
startup_failure
```

A caller's `permissions:` is a **ceiling** for the workflow it calls. `rios0rios0/pipelines` declares `id-token: write` on both reusable definitions, so a caller that grants less is rejected by GitHub before any step executes.

## Why the scope is required

Unless a `github_token` is passed explicitly, `anthropics/claude-code-action`'s `setupGitHubToken()` always requests a GitHub OIDC token and exchanges it for a **GitHub App token** — that is how it posts reviews and comments:

```ts
const oidcToken = await retryWithBackoff(() => getOidcToken());   // needs id-token: write
const appToken  = await retryWithBackoff(() => exchangeForAppToken(oidcToken, permissions));
```

Two independent authentications, which is what I conflated when I removed it:

| Credential | Authenticates to | Needs `id-token: write` |
|---|---|---|
| `CLAUDE_CODE_OAUTH_TOKEN` | Anthropic | no |
| OIDC → GitHub App token | GitHub | **yes** |

## Content

Both files are restored to the canonical fleet text — byte-identical across all 75 repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6B21LbgQKbpL1JzDdBXDe
